### PR TITLE
Add place holders for RetailCustomer Function Blocks & update [FB_14] Authorization and Authentication Test Suite to use genericGetMockServer for /resource APIs

### DIFF
--- a/SOAPUI/GBCMD-soapui-project.xml
+++ b/SOAPUI/GBCMD-soapui-project.xml
@@ -4581,6 +4581,10 @@ def config = new ConfigSlurper().parse(new File(groovyUtils.projectPath + "/etc/
 def target = new ConfigSlurper().parse(new File(groovyUtils.projectPath + "/etc/gbcmdcert_target.conf").toURL())
 def uri;
 
+propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid token - registration_access_token");
+service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+genericGetServiceMockPort = service.getPropertyValue("mockPort");
+
 
 // external program system commands
 project.setPropertyValue("opensslCmd",config.opensslCmd);
@@ -8577,7 +8581,7 @@ if(context["driver"] != null){
 	context["driver"] = null;	
 }
 
-</con:tearDownScript><con:properties><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>access_token</con:name><con:value>6a5b9f1e-e230-45ac-9ccc-d8d1e55cea63</con:value></con:property><con:property><con:name>resourceURI</con:name><con:value>espi/1_1/resource</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>token_type</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>refresh_token</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>expires_in</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>scope</con:name><con:value>FB=4_5_15;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>error</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>old_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">6a5b9f1e-e230-45ac-9ccc-d8d1e55cea63</con:value></con:property><con:property><con:name>client_secret</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">secret</con:value></con:property><con:property><con:name>authorizationServerProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>resourceServerProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>mockPort</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">8080</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpointProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>authorizationServerTokenEndpointProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>client_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">f5fd75d4-fbed-411f-87d8-a1d62ffd6f76</con:value></con:property><con:property><con:name>resourceServer</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">localhost:8443</con:value></con:property><con:property><con:name>registration_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">a46136be-3a9e-45ab-84ce-d59ec2021e98</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="RunCommand" searchProperties="true" id="a3ec95e4-9f8e-40f3-a3ce-37609ecfe6e3"><con:settings/><con:testStep type="groovy" name="runCommand" id="06648a84-6352-4b25-b179-693e52d162cc"><con:settings/><con:config><script>def project = testRunner.testCase.testSuite.project
+</con:tearDownScript><con:properties><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>access_token</con:name><con:value>37e2007a-d8b3-485c-a0b4-e999e74d85e6</con:value></con:property><con:property><con:name>resourceURI</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource/Authorization/7</con:value></con:property><con:property><con:name>token_type</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">bearer</con:value></con:property><con:property><con:name>refresh_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">69ac8735-ec76-4f16-a8f3-587549b76ef8</con:value></con:property><con:property><con:name>expires_in</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">315359999</con:value></con:property><con:property><con:name>scope</con:name><con:value>FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">vgt33r</con:value></con:property><con:property><con:name>error</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>old_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">89054d73-2f13-4813-b823-725d1d9339d9</con:value></con:property><con:property><con:name>client_secret</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">secret</con:value></con:property><con:property><con:name>authorizationServerProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>resourceServerProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>mockPort</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">8080</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpointProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>authorizationServerTokenEndpointProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>client_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">84810c5e-2bfd-4e74-9d39-73d3e1061fc8</con:value></con:property><con:property><con:name>resourceServer</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">localhost:8443</con:value></con:property><con:property><con:name>registration_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">64af3a73-e506-4984-a78d-ece429139491</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="RunCommand" searchProperties="true" id="a3ec95e4-9f8e-40f3-a3ce-37609ecfe6e3"><con:settings/><con:testStep type="groovy" name="runCommand" id="06648a84-6352-4b25-b179-693e52d162cc"><con:settings/><con:config><script>def project = testRunner.testCase.testSuite.project
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -40170,7 +40174,7 @@ if(context["driver"] != null){
 }
 
 log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();
-</con:tearDownScript><con:properties><con:property><con:name>extracted_scope_sel_uri</con:name><con:value/></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">6700CCAC35D61459489B791FB9AC5D58</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD002 [NEG] Authorization Code Request (Retail Customer Passes Authentication and DENIES access)" searchProperties="true" id="bccca4c3-2b7b-4359-8ca2-2159ecd05c3e"><con:description/><con:settings/><con:testStep type="groovy" name="Start Mock Service" id="d08db03c-02df-4bec-be6d-8eb8cd7f4cda"><con:settings/><con:config><script>//	Create addressability to global variables
+</con:tearDownScript><con:properties><con:property><con:name>extracted_scope_sel_uri</con:name><con:value/></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">EA7B29EEE798C31352E88F693CEBCB65</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD002 [NEG] Authorization Code Request (Retail Customer Passes Authentication and DENIES access)" searchProperties="true" id="bccca4c3-2b7b-4359-8ca2-2159ecd05c3e"><con:description/><con:settings/><con:testStep type="groovy" name="Start Mock Service" id="d08db03c-02df-4bec-be6d-8eb8cd7f4cda"><con:settings/><con:config><script>//	Create addressability to global variables
 def authCase = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
 
 context.mockService = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Authorization Mock Service");
@@ -41186,8 +41190,7 @@ if(context["driver"] != null){
 	context["driver"] = null;	
 }
 
-log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>http://localhost:8080/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=third_party</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>http://localhost:8080/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>http://localhost:8081/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>http://localhost:8080/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value>8TmRz3</con:value></con:property><con:property><con:name>tokenResponse</con:name><con:value>{"access_token":"6a5b9f1e-e230-45ac-9ccc-d8d1e55cea63","token_type":"bearer","refresh_token":"5b93cd92-0490-4d49-9fdf-67fc5428875f","expires_in":315359999,"scope":"FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13","resourceURI":"https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7","authorizationURI":"https://localhost:8443/DataCustodian/espi/1_1/resource/Authorization/7"}
-</con:value></con:property><con:property><con:name>access_token</con:name><con:value>039121fb-af73-4669-b972-4b4f9fd2281a</con:value></con:property><con:property><con:name>token_type</con:name><con:value>bearer</con:value></con:property><con:property><con:name>refresh_token</con:name><con:value>d7ba0b90-70ea-41a1-82dc-3e9b6e8361c8</con:value></con:property><con:property><con:name>expires_in</con:name><con:value>119</con:value></con:property><con:property><con:name>scope</con:name><con:value>FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>resourceURI</con:name><con:value>http://localhost:8080/DataCustodian/espi/1_1/resource/Batch/Subscription/5</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>http://localhost:8080/DataCustodian/espi/1_1/resource/Authorization/5</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD006 [NEG] Invalid Access Token Requests for ApplicationInformation" searchProperties="true" id="12b61b3f-7940-4953-8d46-715534e8ee86"><con:settings/><con:testStep type="restrequest" name="GET ApplicationInformation with incorrect Access Token &quot;client_access_token&quot;" id="462ea7ae-1c68-4eef-8f9c-94930aad47e5"><con:settings/><con:config service="ESPI Resources" resourcePath="/${#Project#resourceUri}/ApplicationInformation/{applicationInformationId}" methodName="GET ApplicationInformation by Id" xsi:type="con:RestRequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:restRequest name="GET ApplicationInformation with incorrect Access Token &quot;client_access_token&quot;" mediaType="application/json" id="0d460b8f-6180-470f-8743-6566120cacb6">
+log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>http://localhost:8080/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=third_party</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>http://localhost:8080/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>http://localhost:8081/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>http://localhost:8080/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value>8TmRz3</con:value></con:property><con:property><con:name>tokenResponse</con:name><con:value>{"access_token":"89054d73-2f13-4813-b823-725d1d9339d9","token_type":"bearer","refresh_token":"69ac8735-ec76-4f16-a8f3-587549b76ef8","expires_in":315359999,"scope":"FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13","resourceURI":"https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7","authorizationURI":"https://localhost:8443/DataCustodian/espi/1_1/resource/Authorization/7"}</con:value></con:property><con:property><con:name>access_token</con:name><con:value>039121fb-af73-4669-b972-4b4f9fd2281a</con:value></con:property><con:property><con:name>token_type</con:name><con:value>bearer</con:value></con:property><con:property><con:name>refresh_token</con:name><con:value>d7ba0b90-70ea-41a1-82dc-3e9b6e8361c8</con:value></con:property><con:property><con:name>expires_in</con:name><con:value>119</con:value></con:property><con:property><con:name>scope</con:name><con:value>FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>resourceURI</con:name><con:value>http://localhost:8080/DataCustodian/espi/1_1/resource/Batch/Subscription/5</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>http://localhost:8080/DataCustodian/espi/1_1/resource/Authorization/5</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD006 [NEG] Invalid Access Token Requests for ApplicationInformation" searchProperties="true" id="12b61b3f-7940-4953-8d46-715534e8ee86"><con:settings/><con:testStep type="restrequest" name="GET ApplicationInformation with incorrect Access Token &quot;client_access_token&quot;" id="462ea7ae-1c68-4eef-8f9c-94930aad47e5"><con:settings/><con:config service="ESPI Resources" resourcePath="/${#Project#resourceUri}/ApplicationInformation/{applicationInformationId}" methodName="GET ApplicationInformation by Id" xsi:type="con:RestRequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:restRequest name="GET ApplicationInformation with incorrect Access Token &quot;client_access_token&quot;" mediaType="application/json" id="0d460b8f-6180-470f-8743-6566120cacb6">
 
 					<con:settings>
 						<con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
@@ -41358,48 +41361,248 @@ log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  contex
 		</con:parameterOrder>
 	</con:restRequest></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties/></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD009 [NEG] Invalid Access Token Request (GET RESTful Batch/Subscription request contains registration_access_token)" searchProperties="true" id="f07529bb-9d3e-4f0f-a4aa-60be839b6702"><con:settings/><con:testStep type="groovy" name="Extract information from authorization for registration access token" id="cffeef24-4c55-497a-9480-97dc2f280b4d"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
 
+def authResourceURI;
+def genericGetMockServerURI;
+def headers = new StringToStringMap();
+def project = testRunner.testCase.testSuite.project
 def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+def resourceURI;
 
 propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid token - registration_access_token");
-def headers = new StringToStringMap();
+service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+genericGetServiceMockPort = service.getPropertyValue("mockPort");
 
-propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
+// Convert URL to proxy version
+public String GetProxiedUrl(String uri, String proxy)
+{
+	def project = testRunner.testCase.testSuite.project;
+	URL aURL = new URL(uri);
+	String urlproxy="";
+
+	// check for valid url -- at least protocol and host
+	if ( (aURL.getProtocol() == null) || (aURL.getHost()==null ))
+	{
+		testRunner.fail("unparsable url: "+ uri);	
+	}
+	else
+	{
+		//String proxyOutPort = project.getPropertyValue("proxyOutPort");
+		log.info "Port = " + aURL.getPort();
+		if (aURL.getQuery() != null) {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath() + "?"+ aURL.getQuery();
+		}
+		else {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath();
+		}
+		log.info "Converted = " + urlproxy;
+	}
+
+	return urlproxy;
+}
+
+//def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+
+//propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid token - registration_access_token");
+//service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+//genericGetServiceMockPort = service.getPropertyValue("mockPort");
+//def headers = new StringToStringMap();
+
+// Convert Resource URI to use GenericGetMockServer proxy
+resourceURI = propCreateAuthResults.getPropertyValue("resourceURI");
+log.info("Data Custodian Resource URI: " + resourceURI);
+tempResourceURI = resourceURI;
+i = tempResourceURI.indexOf("espi/1_1/resource");
+if (i>0) {
+	// Strip off everything up to the resource
+	tempResourceURI = tempResourceURI.substring(0,i-1);
+	log.info("Data Custodian Service Endpoint: " + tempResourceURI);
+
+	genericGetMockServerURI = GetProxiedUrl(tempResourceURI, genericGetServiceMockPort);
+//	project.setPropertyValue("ServiceEndpoint",tempResourceURI);
+	log.info("genericGetMockServerURI: " + genericGetMockServerURI);
+
+	tempResourceURI = resourceURI;
+	authResourceURI = tempResourceURI.substring(tempResourceURI.indexOf("espi/1_1/resource"), tempResourceURI.length());
+//	project.setPropertyValue("resourceUri",tempResourceURI);
+	log.info("authResourceURI: " + authResourceURI);	
+	
+} else {
+	// Resource URI is improperly formed
+	log.error("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+	testRunner.fail("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+}
+
+//propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
+propTestStep.setPropertyValue("Endpoint",genericGetMockServerURI + "/" + authResourceURI);
+log.info("TestStep Endpoint: " + propTestStep.getPropertyValue("Endpoint"));
+
 headers.put("Authorization","Bearer " + testRunner.testCase.testSuite.project.getPropertyValue("registration_access_token"));
 headers.put("Content-Type","Application/atom+xml");
-propTestStep.testRequest.setRequestHeaders(headers);
-
- </script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI with invalid token - registration_access_token" id="1f7a25f2-5942-442e-8cd4-d794bf02dbcb"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI with invalid token - registration_access_token" id="7e0ce768-b7c3-4761-89a3-3ef6c6b514bd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
-  &lt;con:entry key="Authorization" value="Bearer d3d3c69d-5e59-48b4-a49d-1eec7a0ad924"/>
+propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI with invalid token - registration_access_token" id="1f7a25f2-5942-442e-8cd4-d794bf02dbcb"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI with invalid token - registration_access_token" id="7e0ce768-b7c3-4761-89a3-3ef6c6b514bd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
+  &lt;con:entry key="Authorization" value="Bearer 64af3a73-e506-4984-a78d-ece429139491"/>
   &lt;con:entry key="Content-Type" value="Application/atom+xml"/>
-&lt;/xml-fragment></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="b7d6602d-3abf-4ef6-9551-432d1d99748b"><con:configuration><codes>403</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:testStep type="groovy" name="Extract information from authorization for client access token" id="c354976a-44ca-4f45-b9fc-dc570dd167b7"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
+&lt;/xml-fragment></con:setting></con:settings><con:endpoint>http://localhost:8086/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="b7d6602d-3abf-4ef6-9551-432d1d99748b"><con:configuration><codes>403</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:testStep type="groovy" name="Extract information from authorization for client access token" id="c354976a-44ca-4f45-b9fc-dc570dd167b7"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
 
+def authResourceURI;
+def genericGetMockServerURI;
+def headers = new StringToStringMap();
+def project = testRunner.testCase.testSuite.project
 def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+def resourceURI;
 
 propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid token - client_access_token");
-def headers = new StringToStringMap();
+service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+genericGetServiceMockPort = service.getPropertyValue("mockPort");
 
-propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
+// Convert URL to proxy version
+public String GetProxiedUrl(String uri, String proxy)
+{
+	def project = testRunner.testCase.testSuite.project;
+	URL aURL = new URL(uri);
+	String urlproxy="";
+
+	// check for valid url -- at least protocol and host
+	if ( (aURL.getProtocol() == null) || (aURL.getHost()==null ))
+	{
+		testRunner.fail("unparsable url: "+ uri);	
+	}
+	else
+	{
+		//String proxyOutPort = project.getPropertyValue("proxyOutPort");
+		log.info "Port = " + aURL.getPort();
+		if (aURL.getQuery() != null) {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath() + "?"+ aURL.getQuery();
+		}
+		else {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath();
+		}
+		log.info "Converted = " + urlproxy;
+	}
+
+	return urlproxy;
+}
+
+//def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+
+//propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid token - registration_access_token");
+//service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+//genericGetServiceMockPort = service.getPropertyValue("mockPort");
+//def headers = new StringToStringMap();
+
+// Convert Resource URI to use GenericGetMockServer proxy
+resourceURI = propCreateAuthResults.getPropertyValue("resourceURI");
+log.info("Data Custodian Resource URI: " + resourceURI);
+tempResourceURI = resourceURI;
+i = tempResourceURI.indexOf("espi/1_1/resource");
+if (i>0) {
+	// Strip off everything up to the resource
+	tempResourceURI = tempResourceURI.substring(0,i-1);
+	log.info("Data Custodian Service Endpoint: " + tempResourceURI);
+
+	genericGetMockServerURI = GetProxiedUrl(tempResourceURI, genericGetServiceMockPort);
+//	project.setPropertyValue("ServiceEndpoint",tempResourceURI);
+	log.info("genericGetMockServerURI: " + genericGetMockServerURI);
+
+	tempResourceURI = resourceURI;
+	authResourceURI = tempResourceURI.substring(tempResourceURI.indexOf("espi/1_1/resource"), tempResourceURI.length());
+//	project.setPropertyValue("resourceUri",tempResourceURI);
+	log.info("authResourceURI: " + authResourceURI);	
+	
+} else {
+	// Resource URI is improperly formed
+	log.error("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+	testRunner.fail("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+}
+
+//propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
+propTestStep.setPropertyValue("Endpoint",genericGetMockServerURI + "/" + authResourceURI);
+log.info("TestStep Endpoint: " + propTestStep.getPropertyValue("Endpoint"));
+
 headers.put("Authorization","Bearer " + testRunner.testCase.testSuite.project.getPropertyValue("client_access_token"));
 headers.put("Content-Type","Application/atom+xml");
-propTestStep.testRequest.setRequestHeaders(headers);
-
- </script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI with invalid token - client_access_token" id="290b25d3-4f23-4749-b71d-bc1ebb20242c"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI with invalid token - client_access_token" id="0f6fd866-deee-40a4-abc0-8e5e03a7a6a6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
-  &lt;con:entry key="Authorization" value="Bearer 5c991f51-d834-47d0-8ae7-9d1fba89bccf"/>
+propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI with invalid token - client_access_token" id="290b25d3-4f23-4749-b71d-bc1ebb20242c"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI with invalid token - client_access_token" id="0f6fd866-deee-40a4-abc0-8e5e03a7a6a6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
+  &lt;con:entry key="Authorization" value="Bearer 84810c5e-2bfd-4e74-9d39-73d3e1061fc8"/>
   &lt;con:entry key="Content-Type" value="Application/atom+xml"/>
-&lt;/xml-fragment></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="0da9db86-144d-43c6-bd69-73d6a296d0bf"><con:configuration><codes>403</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:testStep type="groovy" name="Extract information from authorization no Authorization Header" id="3cebf954-a715-427b-9d52-a61c62a4e9ff"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
+&lt;/xml-fragment></con:setting></con:settings><con:endpoint>http://localhost:8086/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="0da9db86-144d-43c6-bd69-73d6a296d0bf"><con:configuration><codes>403</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:testStep type="groovy" name="Extract information from authorization no Authorization Header" id="3cebf954-a715-427b-9d52-a61c62a4e9ff"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
 
+def authResourceURI;
+def genericGetMockServerURI;
+def headers = new StringToStringMap();
+def project = testRunner.testCase.testSuite.project
 def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+def resourceURI;
 
 propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid no Authorization Header");
-def headers = new StringToStringMap();
+service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+genericGetServiceMockPort = service.getPropertyValue("mockPort");
 
-propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
+// Convert URL to proxy version
+public String GetProxiedUrl(String uri, String proxy)
+{
+	def project = testRunner.testCase.testSuite.project;
+	URL aURL = new URL(uri);
+	String urlproxy="";
+
+	// check for valid url -- at least protocol and host
+	if ( (aURL.getProtocol() == null) || (aURL.getHost()==null ))
+	{
+		testRunner.fail("unparsable url: "+ uri);	
+	}
+	else
+	{
+		//String proxyOutPort = project.getPropertyValue("proxyOutPort");
+		log.info "Port = " + aURL.getPort();
+		if (aURL.getQuery() != null) {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath() + "?"+ aURL.getQuery();
+		}
+		else {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath();
+		}
+		log.info "Converted = " + urlproxy;
+	}
+
+	return urlproxy;
+}
+
+//def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+
+//propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid token - registration_access_token");
+//service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+//genericGetServiceMockPort = service.getPropertyValue("mockPort");
+//def headers = new StringToStringMap();
+
+// Convert Resource URI to use GenericGetMockServer proxy
+resourceURI = propCreateAuthResults.getPropertyValue("resourceURI");
+log.info("Data Custodian Resource URI: " + resourceURI);
+tempResourceURI = resourceURI;
+i = tempResourceURI.indexOf("espi/1_1/resource");
+if (i>0) {
+	// Strip off everything up to the resource
+	tempResourceURI = tempResourceURI.substring(0,i-1);
+	log.info("Data Custodian Service Endpoint: " + tempResourceURI);
+
+	genericGetMockServerURI = GetProxiedUrl(tempResourceURI, genericGetServiceMockPort);
+//	project.setPropertyValue("ServiceEndpoint",tempResourceURI);
+	log.info("genericGetMockServerURI: " + genericGetMockServerURI);
+
+	tempResourceURI = resourceURI;
+	authResourceURI = tempResourceURI.substring(tempResourceURI.indexOf("espi/1_1/resource"), tempResourceURI.length());
+//	project.setPropertyValue("resourceUri",tempResourceURI);
+	log.info("authResourceURI: " + authResourceURI);	
+	
+} else {
+	// Resource URI is improperly formed
+	log.error("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+	testRunner.fail("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+}
+
+//propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
+propTestStep.setPropertyValue("Endpoint",genericGetMockServerURI + "/" + authResourceURI);
+log.info("TestStep Endpoint: " + propTestStep.getPropertyValue("Endpoint"));
+
 //headers.put("Authorization","Bearer " + testRunner.testCase.testSuite.project.getPropertyValue("client_access_token"));
 headers.put("Content-Type","Application/atom+xml");
-propTestStep.testRequest.setRequestHeaders(headers);
-
- 
- </script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI with invalid no Authorization Header" id="3b093be8-4658-414b-88ed-0933be1debcf"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI with invalid no Authorization Header" id="41a41664-70df-4b61-9766-4a4985321b39" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;entry key="Content-Type" value="Application/atom+xml" xmlns="http://eviware.com/soapui/config"/></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="43e11d14-daf7-4f80-8f97-d377a030b928"><con:configuration><codes>403</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties/></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD010 [NEG] Invalid Access Token Request (GET RESTful ReadServiceStatus request contain invalid access tokens)" searchProperties="true" id="2b179321-2f69-48d8-928d-daf4a9914977"><con:settings/><con:testStep type="restrequest" name="GET ServiceStatus with incorrect access token registration_access_token" id="45031e99-3602-42dd-bd9e-188413e48413">
+propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI with invalid no Authorization Header" id="3b093be8-4658-414b-88ed-0933be1debcf"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI with invalid no Authorization Header" id="41a41664-70df-4b61-9766-4a4985321b39" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;entry key="Content-Type" value="Application/atom+xml" xmlns="http://eviware.com/soapui/config"/></con:setting></con:settings><con:endpoint>http://localhost:8086/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="43e11d14-daf7-4f80-8f97-d377a030b928"><con:configuration><codes>403</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties/></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD010 [NEG] Invalid Access Token Request (GET RESTful ReadServiceStatus request contain invalid access tokens)" searchProperties="true" id="2b179321-2f69-48d8-928d-daf4a9914977"><con:settings/><con:testStep type="restrequest" name="GET ServiceStatus with incorrect access token registration_access_token" id="45031e99-3602-42dd-bd9e-188413e48413">
 		<con:settings/>
 		<con:config service="ESPI Resources" resourcePath="/${#Project#resourceUri}/ReadServiceStatus" methodName="GET ServiceStatus" xsi:type="con:RestRequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 			<con:restRequest name="GET ServiceStatus with incorrect access token registration_access_token" mediaType="application/json" id="60e1ff43-7b61-4173-9448-051a3c6ddf48">
@@ -41659,7 +41862,7 @@ headers.put("Accept","application/json, application/*+json");
 propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="Issue Refresh Token Request" id="1262fb12-8637-4f01-9ddb-1c30c90bacca"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="Issue Refresh Token Request" id="ac1c3c99-f244-4c0b-80f1-9a625c9dc566" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
   &lt;con:entry key="Authorization" value="Basic c3VyZmFjZV90cDpzZWNyZXQ="/>
   &lt;con:entry key="Accept" value="application/json, application/*+json"/>
-&lt;/xml-fragment></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/oauth/token?grant_type=refresh_token&amp;refresh_token=5b93cd92-0490-4d49-9fdf-67fc5428875f&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="fe43d96e-8045-4ffa-b07c-0b6cf3bf04a2"><con:configuration><codes>200</codes></con:configuration></con:assertion><con:assertion type="GroovyScriptAssertion" name="Script Assertion" id="74425cd7-ff3f-4642-8f4d-c7905142c2a2"><con:configuration><scriptText>import groovy.json.JsonSlurper;
+&lt;/xml-fragment></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/oauth/token?grant_type=refresh_token&amp;refresh_token=69ac8735-ec76-4f16-a8f3-587549b76ef8&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="fe43d96e-8045-4ffa-b07c-0b6cf3bf04a2"><con:configuration><codes>200</codes></con:configuration></con:assertion><con:assertion type="GroovyScriptAssertion" name="Script Assertion" id="74425cd7-ff3f-4642-8f4d-c7905142c2a2"><con:configuration><scriptText>import groovy.json.JsonSlurper;
 
 String response = messageExchange.response.contentAsString;
 
@@ -41725,19 +41928,87 @@ propCreateAuthResults.setPropertyValue("resourceURI",tokenResponse.resourceURI);
 propCreateAuthResults.setPropertyValue("authorizationURI",tokenResponse.authorizationURI);
 </script></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD013 [NEG][old A] Valid refresh_token request invalidates prior access_token" searchProperties="true" id="4f1a20e4-8937-4a72-a4d3-35956e1559e0"><con:description/><con:settings/><con:testStep type="groovy" name="Extract information from authorization" id="5593dc25-aef2-493d-972e-e912cfe19188"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
 
-def propCreateAuthResults  = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+def authResourceURI;
+def genericGetMockServerURI;
+def headers = new StringToStringMap();
+def project = testRunner.testCase.testSuite.project
+def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+def resourceURI;
 
 propTestStep = context.testCase.getTestStepByName("GET Resource URI");
-def headers = new StringToStringMap();
+service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+genericGetServiceMockPort = service.getPropertyValue("mockPort");
 
-propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
-headers.put("Authorization","Bearer " + propCreateAuthResults.getPropertyValue("old_access_token"));
+// Convert URL to proxy version
+public String GetProxiedUrl(String uri, String proxy)
+{
+	def project = testRunner.testCase.testSuite.project;
+	URL aURL = new URL(uri);
+	String urlproxy="";
+
+	// check for valid url -- at least protocol and host
+	if ( (aURL.getProtocol() == null) || (aURL.getHost()==null ))
+	{
+		testRunner.fail("unparsable url: "+ uri);	
+	}
+	else
+	{
+		//String proxyOutPort = project.getPropertyValue("proxyOutPort");
+		log.info "Port = " + aURL.getPort();
+		if (aURL.getQuery() != null) {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath() + "?"+ aURL.getQuery();
+		}
+		else {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath();
+		}
+		log.info "Converted = " + urlproxy;
+	}
+
+	return urlproxy;
+}
+
+//def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+
+//propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid token - registration_access_token");
+//service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+//genericGetServiceMockPort = service.getPropertyValue("mockPort");
+//def headers = new StringToStringMap();
+
+// Convert Resource URI to use GenericGetMockServer proxy
+resourceURI = propCreateAuthResults.getPropertyValue("resourceURI");
+log.info("Data Custodian Resource URI: " + resourceURI);
+tempResourceURI = resourceURI;
+i = tempResourceURI.indexOf("espi/1_1/resource");
+if (i>0) {
+	// Strip off everything up to the resource
+	tempResourceURI = tempResourceURI.substring(0,i-1);
+	log.info("Data Custodian Service Endpoint: " + tempResourceURI);
+
+	genericGetMockServerURI = GetProxiedUrl(tempResourceURI, genericGetServiceMockPort);
+//	project.setPropertyValue("ServiceEndpoint",tempResourceURI);
+	log.info("genericGetMockServerURI: " + genericGetMockServerURI);
+
+	tempResourceURI = resourceURI;
+	authResourceURI = tempResourceURI.substring(tempResourceURI.indexOf("espi/1_1/resource"), tempResourceURI.length());
+//	project.setPropertyValue("resourceUri",tempResourceURI);
+	log.info("authResourceURI: " + authResourceURI);	
+	
+} else {
+	// Resource URI is improperly formed
+	log.error("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+	testRunner.fail("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+}
+
+//propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
+propTestStep.setPropertyValue("Endpoint",genericGetMockServerURI + "/" + authResourceURI);
+log.info("TestStep Endpoint: " + propTestStep.getPropertyValue("Endpoint"));
+
+headers.put("Authorization","Bearer " + testRunner.testCase.testSuite.project.getPropertyValue("old_access_token"));
 headers.put("Content-Type","Application/atom+xml");
-propTestStep.testRequest.setRequestHeaders(headers);
-</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI" id="696a3a5b-eca2-455b-a640-c9fb7771b160"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI" id="906e45eb-c342-4057-b30a-6e9dee28e1e2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
-  &lt;con:entry key="Authorization" value="Bearer 6a5b9f1e-e230-45ac-9ccc-d8d1e55cea63"/>
+propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI" id="696a3a5b-eca2-455b-a640-c9fb7771b160"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI" id="906e45eb-c342-4057-b30a-6e9dee28e1e2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
+  &lt;con:entry key="Authorization" value="Bearer null"/>
   &lt;con:entry key="Content-Type" value="Application/atom+xml"/>
-&lt;/xml-fragment></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="6858de9d-d648-4132-bb21-fd727a59a1e1"><con:configuration><codes>401</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()
+&lt;/xml-fragment></con:setting></con:settings><con:endpoint>http://localhost:8086/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="6858de9d-d648-4132-bb21-fd727a59a1e1"><con:configuration><codes>401</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()
 
 testRunner.testCase.setPropertyValue("testsPerformed","");
 
@@ -41951,21 +42222,89 @@ if(result==false) {
 	return;	
 }
 
-assert true;</script></con:config></con:testStep><con:testStep type="groovy" name="Extract information from authorization" id="84909737-fd1d-41f7-af0e-ab3a1fdc9426"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
+assert true;</script></con:config></con:testStep><con:testStep type="groovy" name="Extract information from authorization for access_token" id="84909737-fd1d-41f7-af0e-ab3a1fdc9426"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
 
-def propCreateAuthResults  = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+def authResourceURI;
+def genericGetMockServerURI;
+def headers = new StringToStringMap();
+def project = testRunner.testCase.testSuite.project
+def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+def resourceURI;
 
 propTestStep = context.testCase.getTestStepByName("GET Resource URI");
-def headers = new StringToStringMap();
+service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+genericGetServiceMockPort = service.getPropertyValue("mockPort");
 
-propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
-headers.put("Authorization","Bearer " + propCreateAuthResults.getPropertyValue("access_token"));
+// Convert URL to proxy version
+public String GetProxiedUrl(String uri, String proxy)
+{
+	def project = testRunner.testCase.testSuite.project;
+	URL aURL = new URL(uri);
+	String urlproxy="";
+
+	// check for valid url -- at least protocol and host
+	if ( (aURL.getProtocol() == null) || (aURL.getHost()==null ))
+	{
+		testRunner.fail("unparsable url: "+ uri);	
+	}
+	else
+	{
+		//String proxyOutPort = project.getPropertyValue("proxyOutPort");
+		log.info "Port = " + aURL.getPort();
+		if (aURL.getQuery() != null) {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath() + "?"+ aURL.getQuery();
+		}
+		else {
+			urlproxy = "http://" +  "localhost" + ":"+proxy + aURL.getPath();
+		}
+		log.info "Converted = " + urlproxy;
+	}
+
+	return urlproxy;
+}
+
+//def propCreateAuthResults = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
+
+//propTestStep = context.testCase.getTestStepByName("GET Resource URI with invalid token - registration_access_token");
+//service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+//genericGetServiceMockPort = service.getPropertyValue("mockPort");
+//def headers = new StringToStringMap();
+
+// Convert Resource URI to use GenericGetMockServer proxy
+resourceURI = propCreateAuthResults.getPropertyValue("resourceURI");
+log.info("Data Custodian Resource URI: " + resourceURI);
+tempResourceURI = resourceURI;
+i = tempResourceURI.indexOf("espi/1_1/resource");
+if (i>0) {
+	// Strip off everything up to the resource
+	tempResourceURI = tempResourceURI.substring(0,i-1);
+	log.info("Data Custodian Service Endpoint: " + tempResourceURI);
+
+	genericGetMockServerURI = GetProxiedUrl(tempResourceURI, genericGetServiceMockPort);
+//	project.setPropertyValue("ServiceEndpoint",tempResourceURI);
+	log.info("genericGetMockServerURI: " + genericGetMockServerURI);
+
+	tempResourceURI = resourceURI;
+	authResourceURI = tempResourceURI.substring(tempResourceURI.indexOf("espi/1_1/resource"), tempResourceURI.length());
+//	project.setPropertyValue("resourceUri",tempResourceURI);
+	log.info("authResourceURI: " + authResourceURI);	
+	
+} else {
+	// Resource URI is improperly formed
+	log.error("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+	testRunner.fail("Data Custodian Authorization Resource URI is improperly formed: " + resourceURI);
+}
+
+//propTestStep.setPropertyValue("Endpoint",propCreateAuthResults.getPropertyValue("resourceURI"));
+propTestStep.setPropertyValue("Endpoint",genericGetMockServerURI + "/" + authResourceURI);
+log.info("TestStep Endpoint: " + propTestStep.getPropertyValue("Endpoint"));
+
+headers.put("Authorization","Bearer " + testRunner.testCase.testSuite.project.getPropertyValue("access_token"));
 headers.put("Content-Type","Application/atom+xml");
-propTestStep.testRequest.setRequestHeaders(headers);
-</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI" id="7833b236-0569-4845-a351-1e6e154ee057"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI" id="91e703ef-4710-480e-bfad-da8a2bc3cf6a" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
-  &lt;con:entry key="Authorization" value="Bearer 0b5e21ef-f277-49a3-b7e4-a3d9cf3221b1"/>
+propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI" id="7833b236-0569-4845-a351-1e6e154ee057"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI" id="91e703ef-4710-480e-bfad-da8a2bc3cf6a" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
+  &lt;con:entry key="Authorization" value="Bearer 89054d73-2f13-4813-b823-725d1d9339d9"/>
   &lt;con:entry key="Content-Type" value="Application/atom+xml"/>
-&lt;/xml-fragment></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="797c5efb-fa4e-482e-b8ea-e9dc2e9e94f4"><con:configuration><codes>401</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property></con:properties></con:testCase><con:properties/>
+&lt;/xml-fragment></con:setting></con:settings><con:endpoint>http://localhost:8086/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="797c5efb-fa4e-482e-b8ea-e9dc2e9e94f4"><con:configuration><codes>401</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property></con:properties></con:testCase><con:properties/>
 <con:setupScript>log.info "===== Start TestSuite =====> " + testSuite.name</con:setupScript><con:tearDownScript>def results = true;
 
 log.info "===== SUMMARY   TestSuite =====> " + testSuite.name
@@ -45515,7 +45854,7 @@ if(results == true) {
 else {
 	log.info "===== FAILED End   TestSuite =====> " + testSuite.name
 }
-</con:tearDownScript></con:testSuite><con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty Notification REST MockService 1" docroot="" id="44aa183e-c020-4e6b-8402-539544493841"><con:settings/><con:startScript>context.mockService.setPropertyValue("rxNotificationBody","");</con:startScript><con:properties><con:property><con:name>rxNotificationBody</con:name><con:value/></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:onRequestScript/><con:restMockAction name="/ThirdParty/espi/1_1/Notification" method="POST" resourcePath="/ThirdParty/espi/1_1/Notification" id="6b6053c9-2c1a-4384-9b10-782eb51bbd4c"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>if(requestContext.mockService.getPropertyValue("rxNotificationBody")!= "") {
+</con:tearDownScript></con:testSuite><con:testSuite id="777829b5-238f-498b-8fca-fc91f28b2179" name="[FUTURE]*[FB_46] Core RetailCustomer"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="e6e692e4-a3af-493f-879e-e29d98472396" name="[FUTURE]*[FB_47] REST for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="134c0d4e-41b7-43ef-99a7-82910fc15181" name="[FUTURE]*[FB_48] SFTP for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="5f220152-b482-4fe6-a93c-c86983aa59ab" name="[FUTURE]*[FB_49] RetailCustomer Management REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="a4cad8a6-a545-43a7-813d-41f895c2ba75" name="[FUTURE]*[FB_50] RetailCustomer Resource Level REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty Notification REST MockService 1" docroot="" id="44aa183e-c020-4e6b-8402-539544493841"><con:settings/><con:startScript>context.mockService.setPropertyValue("rxNotificationBody","");</con:startScript><con:properties><con:property><con:name>rxNotificationBody</con:name><con:value/></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:onRequestScript/><con:restMockAction name="/ThirdParty/espi/1_1/Notification" method="POST" resourcePath="/ThirdParty/espi/1_1/Notification" id="6b6053c9-2c1a-4384-9b10-782eb51bbd4c"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>if(requestContext.mockService.getPropertyValue("rxNotificationBody")!= "") {
 	log.info("ThirdParty Notification REST MockService 1 (/ThirdParty/espi/1_1/Notification) Discarding additional notifications");
 	return;	
 }
@@ -46457,7 +46796,7 @@ log.info("ThirdParty NEG A tests Authorization Mock Service (GET /Default Respon
 strRequestPath = mockRequest.getPath();
 log.info("ThirdParty NEG A tests Authorization Mock Service (GET /Default Response) Request Path: " + strRequestPath);
 </con:script><con:responseContent/></con:response></con:restMockAction></con:restMockService>
-<con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty NEG B tests Authorization Mock Service" docroot="" id="f53ba382-c35f-4ef1-901a-f07c7855c1b3"><con:settings/><con:properties><con:property><con:name>tokenResponse</con:name><con:value/></con:property><con:property><con:name>SelectedScope</con:name><con:value>scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>DataCustodianAuthorizeQry</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_6_7_8_9_10_11_29_12_13_14_15_16_17_18_19_27_28_32_33_34_35_37_38_39_40_41_44;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;DataCustodianID=data_custodian</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value>9C0B4BBAD2FBDAF475058F4996FE725B</con:value></con:property><con:property><con:name>GotFirstRedirect</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>ExtractedSessionID</con:name><con:value>FALSE</con:value></con:property><con:property><con:name>GotScopeSelPOST</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value>8Bmbhr</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>client_secret</con:name><con:value>secret</con:value></con:property><con:property><con:name>state</con:name><con:value>ee148ec2-9892-466e-a013-4dedf1eb3018</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:restMockAction name="/ThirdParty/RetailCustomer/ScopeSelection" method="GET" resourcePath="/ThirdParty/RetailCustomer/ScopeSelection" id="80ce918e-62e8-4eb0-881e-fe7226c68892"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+<con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty NEG B tests Authorization Mock Service" docroot="" id="f53ba382-c35f-4ef1-901a-f07c7855c1b3"><con:settings/><con:properties><con:property><con:name>tokenResponse</con:name><con:value/></con:property><con:property><con:name>SelectedScope</con:name><con:value>scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>DataCustodianAuthorizeQry</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_6_7_8_9_10_11_29_12_13_14_15_16_17_18_19_27_28_32_33_34_35_37_38_39_40_41_44;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;DataCustodianID=data_custodian</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value>9C0B4BBAD2FBDAF475058F4996FE725B</con:value></con:property><con:property><con:name>GotFirstRedirect</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>ExtractedSessionID</con:name><con:value>FALSE</con:value></con:property><con:property><con:name>GotScopeSelPOST</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value>vgt33r</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>client_secret</con:name><con:value>secret</con:value></con:property><con:property><con:name>state</con:name><con:value>ee148ec2-9892-466e-a013-4dedf1eb3018</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:restMockAction name="/ThirdParty/RetailCustomer/ScopeSelection" method="GET" resourcePath="/ThirdParty/RetailCustomer/ScopeSelection" id="80ce918e-62e8-4eb0-881e-fe7226c68892"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
 // Examples showing how to match based on path, query param and header
 // Match based on path
 def requestPath = mockRequest.getPath()
@@ -47220,7 +47559,7 @@ responses.each { it->
 context.responseCode = 200;
 
 return 
-]]></con:dispatchPath><con:response name="GenericGetService Response" id="79bee9b3-4989-409b-8389-1bb5f4cf90d3" httpResponseStatus="200"><con:settings/><con:script>mockResponse.setResponseHttpStatus(context.responseCode);</con:script><con:responseContent>${proxiedResponse}</con:responseContent></con:response></con:restMockAction></con:restMockService><con:restMockService id="be1ca609-7ac8-4800-9d34-770c90a6e5a7" port="8085" path="/" host="openespivm" name="DC Simulator for Unit Testing - Immediate Response" docroot=""><con:settings/><con:properties/><con:restMockAction name="/" method="GET" resourcePath="/" id="095ce477-10b3-46d3-b050-13b86093009b"><con:settings/><con:defaultResponse>Response 200</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+]]></con:dispatchPath><con:response name="GenericGetService Response" id="79bee9b3-4989-409b-8389-1bb5f4cf90d3" httpResponseStatus="401"><con:settings/><con:script>mockResponse.setResponseHttpStatus(context.responseCode);</con:script><con:responseContent>${proxiedResponse}</con:responseContent></con:response></con:restMockAction></con:restMockService><con:restMockService id="be1ca609-7ac8-4800-9d34-770c90a6e5a7" port="8085" path="/" host="openespivm" name="DC Simulator for Unit Testing - Immediate Response" docroot=""><con:settings/><con:properties/><con:restMockAction name="/" method="GET" resourcePath="/" id="095ce477-10b3-46d3-b050-13b86093009b"><con:settings/><con:defaultResponse>Response 200</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
 // Script dispatcher is used to select a response based on the incoming request.
 // Here are few examples showing how to match based on path, query param, header and body
 
@@ -47432,7 +47771,7 @@ if( requestBody.contains("some data") )
 */
 </con:dispatchPath><con:response name="Response 1 - 202" id="552f9a94-4650-43b2-b2a0-f0aa02f07719" httpResponseStatus="202"><con:settings/><con:responseContent/></con:response></con:restMockAction></con:restMockService><con:properties>
 
-	<con:property><con:name>access_token</con:name><con:value>6a5b9f1e-e230-45ac-9ccc-d8d1e55cea63</con:value></con:property><con:property><con:name>applicationInformationId</con:name><con:value>4</con:value></con:property><con:property><con:name>authorizationId</con:name><con:value>6</con:value></con:property><con:property><con:name>authorizationServer</con:name><con:value>localhost:8443</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property>
+	<con:property><con:name>access_token</con:name><con:value>89054d73-2f13-4813-b823-725d1d9339d9</con:value></con:property><con:property><con:name>applicationInformationId</con:name><con:value>4</con:value></con:property><con:property><con:name>authorizationId</con:name><con:value>6</con:value></con:property><con:property><con:name>authorizationServer</con:name><con:value>localhost:8443</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property>
 
 		<con:name>BaseURL</con:name>
 		<con:value/>
@@ -47447,7 +47786,7 @@ if( requestBody.contains("some data") )
 	
 	
 	
-	<con:property><con:name>bulkId</con:name><con:value>1</con:value></con:property><con:property><con:name>certScopes</con:name><con:value>FB=1_4_5_15</con:value></con:property><con:property><con:name>client_access_token</con:name><con:value>f5fd75d4-fbed-411f-87d8-a1d62ffd6f76</con:value></con:property>
+	<con:property><con:name>bulkId</con:name><con:value>1</con:value></con:property><con:property><con:name>certScopes</con:name><con:value>FB=1_4_5_15</con:value></con:property><con:property><con:name>client_access_token</con:name><con:value>84810c5e-2bfd-4e74-9d39-73d3e1061fc8</con:value></con:property>
 	
 	
 	
@@ -47475,7 +47814,7 @@ if( requestBody.contains("some data") )
 	
 	
 	
-	<con:property><con:name>readingTypeId</con:name><con:value>1</con:value></con:property><con:property><con:name>registration_access_token</con:name><con:value>a46136be-3a9e-45ab-84ce-d59ec2021e98</con:value></con:property><con:property><con:name>registration_third_party_access_token</con:name><con:value>c66b0854-ea1f-4e24-afb7-afab9e0f6c5e</con:value></con:property><con:property><con:name>resourceId</con:name><con:value>01</con:value></con:property><con:property><con:name>resourceServer</con:name><con:value>localhost:8443</con:value></con:property><con:property><con:name>resourceServerUri</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource</con:value></con:property><con:property><con:name>resourceUri</con:name><con:value>espi/1_1/resource</con:value></con:property>
+	<con:property><con:name>readingTypeId</con:name><con:value>1</con:value></con:property><con:property><con:name>registration_access_token</con:name><con:value>64af3a73-e506-4984-a78d-ece429139491</con:value></con:property><con:property><con:name>registration_third_party_access_token</con:name><con:value>c66b0854-ea1f-4e24-afb7-afab9e0f6c5e</con:value></con:property><con:property><con:name>resourceId</con:name><con:value>01</con:value></con:property><con:property><con:name>resourceServer</con:name><con:value>localhost:8443</con:value></con:property><con:property><con:name>resourceServerUri</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource</con:value></con:property><con:property><con:name>resourceUri</con:name><con:value>espi/1_1/resource</con:value></con:property>
 	
 	
 	


### PR DESCRIPTION
1) Add place holders for [FUTURE] RetailCustomer Function Block Test Suites
2) Convert [FB_14] Authorization and Authentication Test Cases to use genericGetMockServer for 
    accessing /resource based APIs