### PR TITLE
WIP -- Miscellaneous updates to correct issue causing SoapUI test harness to hang due to multiple mock services running on the same port

### DIFF
--- a/SOAPUI/GBCMD-soapui-project.xml
+++ b/SOAPUI/GBCMD-soapui-project.xml
@@ -4649,22 +4649,30 @@ project.setPropertyValue("proxyOutPort1",config.proxyOutPort1);
 
 // set proxy ports in mock servers
 def service;
-service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 service.setPropertyValue("mockPort",config.mockPort);
 service.setPropertyValue("proxyOutPort",config.proxyOutPort);
 service.setPropertyValue("proxyOutPort1",config.proxyOutPort1);
+
 service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Authorization Mock Service");
 service.setPropertyValue("mockPort",config.mockPort);
 service.setPropertyValue("proxyOutPort",config.proxyOutPort);
 service.setPropertyValue("proxyOutPort1",config.proxyOutPort1);
+
 service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty NEG A tests Authorization Mock Service");
 service.setPropertyValue("mockPort",config.mockPort);
 service.setPropertyValue("proxyOutPort",config.proxyOutPort);
 service.setPropertyValue("proxyOutPort1",config.proxyOutPort1);
+
 service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty NEG B tests Authorization Mock Service");
 service.setPropertyValue("mockPort",config.mockPort);
 service.setPropertyValue("proxyOutPort",config.proxyOutPort);
 service.setPropertyValue("proxyOutPort1",config.proxyOutPort1);
+
+// TODO: Standardize port initialization for "GenericGetService" and "BatchListNotification" Mock services
+//service = testRunner.testCase.testSuite.project.getRestMockServiceByName("GenericGetService");
+
+//service = testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification");
 
 proxyOutPort = service.getPropertyValue("proxyOutPort");
 proxyOutPort1 = service.getPropertyValue("proxyOutPort1");
@@ -8581,7 +8589,7 @@ if(context["driver"] != null){
 	context["driver"] = null;	
 }
 
-</con:tearDownScript><con:properties><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>access_token</con:name><con:value>ccfca4be-0125-43da-983d-7486680c1e7e</con:value></con:property><con:property><con:name>resourceURI</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource/Authorization/7</con:value></con:property><con:property><con:name>token_type</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">bearer</con:value></con:property><con:property><con:name>refresh_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">520ea2d0-1bb1-40b2-88c2-3a592a410d09</con:value></con:property><con:property><con:name>expires_in</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">315359999</con:value></con:property><con:property><con:name>scope</con:name><con:value>FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">JCr2YO</con:value></con:property><con:property><con:name>error</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>old_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">0c2afc5d-0b40-4b41-9dd1-ffadda456a65</con:value></con:property><con:property><con:name>client_secret</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">secret</con:value></con:property><con:property><con:name>authorizationServerProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>resourceServerProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>mockPort</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">8080</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpointProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>authorizationServerTokenEndpointProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>client_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">48fd9d43-1bb4-4f05-b196-0501a8130f07</con:value></con:property><con:property><con:name>resourceServer</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">localhost:8443</con:value></con:property><con:property><con:name>registration_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">4df9fbc0-0841-4b2a-825d-7eaa7936420d</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="RunCommand" searchProperties="true" id="a3ec95e4-9f8e-40f3-a3ce-37609ecfe6e3"><con:settings/><con:testStep type="groovy" name="runCommand" id="06648a84-6352-4b25-b179-693e52d162cc"><con:settings/><con:config><script>def project = testRunner.testCase.testSuite.project
+</con:tearDownScript><con:properties><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>access_token</con:name><con:value>27ce8231-a305-4ace-9ad6-38db321dd12f</con:value></con:property><con:property><con:name>resourceURI</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource/Authorization/7</con:value></con:property><con:property><con:name>token_type</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">bearer</con:value></con:property><con:property><con:name>refresh_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">d9e5553c-448e-4a10-89b6-c83c455bc714</con:value></con:property><con:property><con:name>expires_in</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">315359999</con:value></con:property><con:property><con:name>scope</con:name><con:value>FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">KAGFF3</con:value></con:property><con:property><con:name>error</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>old_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">45a4f829-e9cb-49c8-b16e-12b31dff1bb8</con:value></con:property><con:property><con:name>client_secret</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">secret</con:value></con:property><con:property><con:name>authorizationServerProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>resourceServerProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>mockPort</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">8080</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpointProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>authorizationServerTokenEndpointProxy</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>client_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">98d61eaa-e469-4dd0-81e6-452c09e48837</con:value></con:property><con:property><con:name>resourceServer</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">localhost:8443</con:value></con:property><con:property><con:name>registration_access_token</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">6bf8626f-fbe9-4a63-a1cd-08f80f495f3f</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="RunCommand" searchProperties="true" id="a3ec95e4-9f8e-40f3-a3ce-37609ecfe6e3"><con:settings/><con:testStep type="groovy" name="runCommand" id="06648a84-6352-4b25-b179-693e52d162cc"><con:settings/><con:config><script>def project = testRunner.testCase.testSuite.project
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -40173,7 +40181,7 @@ if(context["driver"] != null){
 }
 
 log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();
-</con:tearDownScript><con:properties><con:property><con:name>extracted_scope_sel_uri</con:name><con:value/></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">55B24178D9F33C5FCF53064237A58D98</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD002 [NEG] Authorization Code Request (Retail Customer Passes Authentication and DENIES access)" searchProperties="true" id="bccca4c3-2b7b-4359-8ca2-2159ecd05c3e"><con:description/><con:settings/><con:testStep type="groovy" name="Start Mock Service" id="d08db03c-02df-4bec-be6d-8eb8cd7f4cda"><con:settings/><con:config><script>//	Create addressability to global variables
+</con:tearDownScript><con:properties><con:property><con:name>extracted_scope_sel_uri</con:name><con:value/></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">0863A76546142CC121BF9BDDC6EB4A8F</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD002 [NEG] Authorization Code Request (Retail Customer Passes Authentication and DENIES access)" searchProperties="true" id="bccca4c3-2b7b-4359-8ca2-2159ecd05c3e"><con:description/><con:settings/><con:testStep type="groovy" name="Start Mock Service" id="d08db03c-02df-4bec-be6d-8eb8cd7f4cda"><con:settings/><con:config><script>//	Create addressability to global variables
 def authCase = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
 
 context.mockService = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Authorization Mock Service");
@@ -41189,7 +41197,8 @@ if(context["driver"] != null){
 	context["driver"] = null;	
 }
 
-log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>http://localhost:8080/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=third_party</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>http://localhost:8080/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>http://localhost:8081/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>http://localhost:8080/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value>8TmRz3</con:value></con:property><con:property><con:name>tokenResponse</con:name><con:value>{"access_token":"a6571ea4-9fde-45dc-a8b5-47d0b959414a","token_type":"bearer","refresh_token":"520ea2d0-1bb1-40b2-88c2-3a592a410d09","expires_in":315359999,"scope":"FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13","resourceURI":"https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7","authorizationURI":"https://localhost:8443/DataCustodian/espi/1_1/resource/Authorization/7"}</con:value></con:property><con:property><con:name>access_token</con:name><con:value>039121fb-af73-4669-b972-4b4f9fd2281a</con:value></con:property><con:property><con:name>token_type</con:name><con:value>bearer</con:value></con:property><con:property><con:name>refresh_token</con:name><con:value>d7ba0b90-70ea-41a1-82dc-3e9b6e8361c8</con:value></con:property><con:property><con:name>expires_in</con:name><con:value>119</con:value></con:property><con:property><con:name>scope</con:name><con:value>FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>resourceURI</con:name><con:value>http://localhost:8080/DataCustodian/espi/1_1/resource/Batch/Subscription/5</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>http://localhost:8080/DataCustodian/espi/1_1/resource/Authorization/5</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD006 [NEG] Invalid Access Token Requests for ApplicationInformation" searchProperties="true" id="12b61b3f-7940-4953-8d46-715534e8ee86"><con:settings/><con:testStep type="restrequest" name="GET ApplicationInformation with incorrect Access Token &quot;client_access_token&quot;" id="462ea7ae-1c68-4eef-8f9c-94930aad47e5"><con:settings/><con:config service="ESPI Resources" resourcePath="/${#Project#resourceUri}/ApplicationInformation/{applicationInformationId}" methodName="GET ApplicationInformation by Id" xsi:type="con:RestRequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:restRequest name="GET ApplicationInformation with incorrect Access Token &quot;client_access_token&quot;" mediaType="application/json" id="0d460b8f-6180-470f-8743-6566120cacb6">
+log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>http://localhost:8080/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=third_party</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>http://localhost:8080/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>http://localhost:8081/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>http://localhost:8080/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value>8TmRz3</con:value></con:property><con:property><con:name>tokenResponse</con:name><con:value>{"access_token":"45a4f829-e9cb-49c8-b16e-12b31dff1bb8","token_type":"bearer","refresh_token":"d9e5553c-448e-4a10-89b6-c83c455bc714","expires_in":315359999,"scope":"FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13","resourceURI":"https://localhost:8443/DataCustodian/espi/1_1/resource/Batch/Subscription/7","authorizationURI":"https://localhost:8443/DataCustodian/espi/1_1/resource/Authorization/7"}
+</con:value></con:property><con:property><con:name>access_token</con:name><con:value>039121fb-af73-4669-b972-4b4f9fd2281a</con:value></con:property><con:property><con:name>token_type</con:name><con:value>bearer</con:value></con:property><con:property><con:name>refresh_token</con:name><con:value>d7ba0b90-70ea-41a1-82dc-3e9b6e8361c8</con:value></con:property><con:property><con:name>expires_in</con:name><con:value>119</con:value></con:property><con:property><con:name>scope</con:name><con:value>FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>resourceURI</con:name><con:value>http://localhost:8080/DataCustodian/espi/1_1/resource/Batch/Subscription/5</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>http://localhost:8080/DataCustodian/espi/1_1/resource/Authorization/5</con:value></con:property></con:properties></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD006 [NEG] Invalid Access Token Requests for ApplicationInformation" searchProperties="true" id="12b61b3f-7940-4953-8d46-715534e8ee86"><con:settings/><con:testStep type="restrequest" name="GET ApplicationInformation with incorrect Access Token &quot;client_access_token&quot;" id="462ea7ae-1c68-4eef-8f9c-94930aad47e5"><con:settings/><con:config service="ESPI Resources" resourcePath="/${#Project#resourceUri}/ApplicationInformation/{applicationInformationId}" methodName="GET ApplicationInformation by Id" xsi:type="con:RestRequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:restRequest name="GET ApplicationInformation with incorrect Access Token &quot;client_access_token&quot;" mediaType="application/json" id="0d460b8f-6180-470f-8743-6566120cacb6">
 
 					<con:settings>
 						<con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
@@ -41437,7 +41446,7 @@ log.info("TestStep Endpoint: " + propTestStep.getPropertyValue("Endpoint"));
 headers.put("Authorization","Bearer " + testRunner.testCase.testSuite.project.getPropertyValue("registration_access_token"));
 headers.put("Content-Type","Application/atom+xml");
 propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI with invalid token - registration_access_token" id="1f7a25f2-5942-442e-8cd4-d794bf02dbcb"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI with invalid token - registration_access_token" id="7e0ce768-b7c3-4761-89a3-3ef6c6b514bd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
-  &lt;con:entry key="Authorization" value="Bearer 4df9fbc0-0841-4b2a-825d-7eaa7936420d"/>
+  &lt;con:entry key="Authorization" value="Bearer 6bf8626f-fbe9-4a63-a1cd-08f80f495f3f"/>
   &lt;con:entry key="Content-Type" value="Application/atom+xml"/>
 &lt;/xml-fragment></con:setting></con:settings><con:endpoint>http://localhost:8086/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="b7d6602d-3abf-4ef6-9551-432d1d99748b"><con:configuration><codes>403</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:testStep type="groovy" name="Extract information from authorization for client access token" id="c354976a-44ca-4f45-b9fc-dc570dd167b7"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
 
@@ -41518,7 +41527,7 @@ log.info("TestStep Endpoint: " + propTestStep.getPropertyValue("Endpoint"));
 headers.put("Authorization","Bearer " + testRunner.testCase.testSuite.project.getPropertyValue("client_access_token"));
 headers.put("Content-Type","Application/atom+xml");
 propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI with invalid token - client_access_token" id="290b25d3-4f23-4749-b71d-bc1ebb20242c"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI with invalid token - client_access_token" id="0f6fd866-deee-40a4-abc0-8e5e03a7a6a6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
-  &lt;con:entry key="Authorization" value="Bearer 48fd9d43-1bb4-4f05-b196-0501a8130f07"/>
+  &lt;con:entry key="Authorization" value="Bearer 98d61eaa-e469-4dd0-81e6-452c09e48837"/>
   &lt;con:entry key="Content-Type" value="Application/atom+xml"/>
 &lt;/xml-fragment></con:setting></con:settings><con:endpoint>http://localhost:8086/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="0da9db86-144d-43c6-bd69-73d6a296d0bf"><con:configuration><codes>403</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:testStep type="groovy" name="Extract information from authorization no Authorization Header" id="3cebf954-a715-427b-9d52-a61c62a4e9ff"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
 
@@ -41830,8 +41839,6 @@ assert true;
 ]]></script></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties/></con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="OAD012 [POS] Valid refresh_token request" searchProperties="true" id="f45a7dc4-3dab-4615-99c3-42b6153fdea3"><con:settings/><con:testStep type="groovy" name="Save old access token" id="b5ea7c6d-15a3-4439-a7bb-21d230bb2f7c"><con:settings/><con:config><script>
 def propCreateAuthResults  = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
 
-log.info("(OAD012 [POS] Valid refresh_token request -- Save old access token) Old access token: " + propCreateAuthResults.getPropertyValue("access_token"));
-
 propCreateAuthResults.setPropertyValue("old_access_token",propCreateAuthResults.getPropertyValue("access_token"));</script></con:config></con:testStep><con:testStep type="groovy" name="Transfer properties to Request" id="56ed3dd2-9912-4d08-90ec-7d3b5e9eee9d"><con:settings/><con:config><script>import com.eviware.soapui.support.types.StringToStringMap;
 
 def propCreateAuthResults  = testRunner.testCase.testSuite.project.testSuites['Library'].testCases['Create Authorization and extract all information'];
@@ -41859,7 +41866,7 @@ headers.put("Accept","application/json, application/*+json");
 propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="Issue Refresh Token Request" id="1262fb12-8637-4f01-9ddb-1c30c90bacca"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="Issue Refresh Token Request" id="ac1c3c99-f244-4c0b-80f1-9a625c9dc566" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
   &lt;con:entry key="Authorization" value="Basic c3VyZmFjZV90cDpzZWNyZXQ="/>
   &lt;con:entry key="Accept" value="application/json, application/*+json"/>
-&lt;/xml-fragment></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/oauth/token?grant_type=refresh_token&amp;refresh_token=520ea2d0-1bb1-40b2-88c2-3a592a410d09&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="fe43d96e-8045-4ffa-b07c-0b6cf3bf04a2"><con:configuration><codes>200</codes></con:configuration></con:assertion><con:assertion type="GroovyScriptAssertion" name="Script Assertion" id="74425cd7-ff3f-4642-8f4d-c7905142c2a2"><con:configuration><scriptText>import groovy.json.JsonSlurper;
+&lt;/xml-fragment></con:setting></con:settings><con:endpoint>https://localhost:8443/DataCustodian/oauth/token?grant_type=refresh_token&amp;refresh_token=d9e5553c-448e-4a10-89b6-c83c455bc714&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="fe43d96e-8045-4ffa-b07c-0b6cf3bf04a2"><con:configuration><codes>200</codes></con:configuration></con:assertion><con:assertion type="GroovyScriptAssertion" name="Script Assertion" id="74425cd7-ff3f-4642-8f4d-c7905142c2a2"><con:configuration><scriptText>import groovy.json.JsonSlurper;
 
 String response = messageExchange.response.contentAsString;
 
@@ -42305,7 +42312,7 @@ log.info("TestStep Endpoint: " + propTestStep.getPropertyValue("Endpoint"));
 headers.put("Authorization","Bearer " + propCreateAuthResults.getPropertyValue("access_token"));
 headers.put("Content-Type","Application/atom+xml");
 propTestStep.testRequest.setRequestHeaders(headers);</script></con:config></con:testStep><con:testStep type="httprequest" name="GET Resource URI" id="7833b236-0569-4845-a351-1e6e154ee057"><con:settings/><con:config method="GET" xsi:type="con:HttpRequest" name="GET Resource URI" id="91e703ef-4710-480e-bfad-da8a2bc3cf6a" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment xmlns:con="http://eviware.com/soapui/config">
-  &lt;con:entry key="Authorization" value="Bearer ccfca4be-0125-43da-983d-7486680c1e7e"/>
+  &lt;con:entry key="Authorization" value="Bearer 27ce8231-a305-4ace-9ad6-38db321dd12f"/>
   &lt;con:entry key="Content-Type" value="Application/atom+xml"/>
 &lt;/xml-fragment></con:setting></con:settings><con:endpoint>http://localhost:8086/DataCustodian/espi/1_1/resource/Batch/Subscription/7</con:endpoint><con:request/><con:assertion type="Valid HTTP Status Codes" name="Valid HTTP Status Codes" id="797c5efb-fa4e-482e-b8ea-e9dc2e9e94f4"><con:configuration><codes>401</codes></con:configuration></con:assertion><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:parameters/></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property></con:properties></con:testCase><con:properties/>
 <con:setupScript>log.info "===== Start TestSuite =====> " + testSuite.name</con:setupScript><con:tearDownScript>def results = true;
@@ -42385,11 +42392,21 @@ else {
 			<con:entry>Authorization</con:entry>
 			<con:entry>Content-Type</con:entry>
 		</con:parameterOrder>
-	</con:restRequest></con:config></con:testStep><con:testStep type="groovy" name="Start Mock Service" id="16a03f52-958d-42e3-9827-9a88349df910"><con:settings/><con:config><script>def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+	</con:restRequest></con:config></con:testStep><con:testStep type="groovy" name="Start Mock Service" id="16a03f52-958d-42e3-9827-9a88349df910"><con:settings/><con:config><script>// Verify BatchListNotification Mock Service is NOT running
+if(testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner() != null) {
+
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) BatchListNotification Mock Service is running!");
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) Stopping BatchListNotification Mock Service!");
+	testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner().stop();
+	
+}
+
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 service.setPropertyValue("rxNotificationBody","");
 
-def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1").start();
+def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service").start();
+
 context.mockRunner = runner;
 
 return;</script></con:config></con:testStep><con:testStep type="manualTestStep" name="Have DataCustodian Issue a Notification message with Batch/Bulk information" id="817bdfe9-ccb6-498a-826b-4e66edf41217"><con:description>From the DataCustodian under test please manually initiate a Notification of Batch/Bulk.
@@ -42804,11 +42821,20 @@ else {
 			<con:entry>Authorization</con:entry>
 			<con:entry>Content-Type</con:entry>
 		</con:parameterOrder>
-	</con:restRequest></con:config></con:testStep><con:testStep type="groovy" name="Start Mock Service" id="ccbed0cd-1972-46cc-b566-ee56a141bb4e"><con:settings/><con:config><script>def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+	</con:restRequest></con:config></con:testStep><con:testStep type="groovy" name="Start Mock Service" id="ccbed0cd-1972-46cc-b566-ee56a141bb4e"><con:settings/><con:config><script>// Verify BatchListNotification Mock Service is NOT running
+if(testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner() != null) {
+
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) BatchListNotification Mock Service is running!");
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) Stopping BatchListNotification Mock Service!");
+	testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner().stop();
+	
+}
+
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 service.setPropertyValue("rxNotificationBody","");
 
-def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1").start();
+def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service").start();
 context.mockRunner = runner;
 
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Request DataCustodian to Issue a Notification message with Batch/Bulk information" id="d49f682e-b375-44c1-aed9-91d8a59558c9"><con:settings/><con:config><script>def ui = com.eviware.soapui.support.UISupport;
@@ -43132,11 +43158,20 @@ return;
 </script></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties/>
 	</con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="RBK_002 [NEG] REST for BULK notification - Forbidden GET access" searchProperties="true" id="09ac5da0-e425-4e64-b809-a0683d860747">
 		<con:settings/>
-		<con:testStep type="groovy" name="Start Mock Service" id="018a6afb-5ce4-4501-8eab-5a7fdfdbbe09"><con:settings/><con:config><script>def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+		<con:testStep type="groovy" name="Start Mock Service" id="018a6afb-5ce4-4501-8eab-5a7fdfdbbe09"><con:settings/><con:config><script>// Verify BatchListNotification Mock Service is NOT running
+if(testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner() != null) {
+
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) BatchListNotification Mock Service is running!");
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) Stopping BatchListNotification Mock Service!");
+	testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner().stop();
+	
+}
+
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 service.setPropertyValue("rxNotificationBody","");
 
-def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1").start();
+def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service").start();
 context.mockRunner = runner;
 
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Request DataCustodian to Issue a Notification message with Batch/Bulk information" id="1843d72d-adc4-42fc-ad36-31258f1881b1"><con:settings/><con:config><script>def ui = com.eviware.soapui.support.UISupport;
@@ -43869,11 +43904,20 @@ else {
 	<con:runType>SEQUENTIAL</con:runType>
 	<con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="PSH001 [POS] Notification Push/POST to ThirdParty of ApplicationInformation" searchProperties="true" id="e0524a81-a243-43f7-9705-67aeb6a6699c">
 		<con:settings/>
-		<con:testStep type="groovy" name="Start Mock Service" id="ba0adc8e-d92f-4ca2-abce-30c246fe6789"><con:settings/><con:config><script>def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+		<con:testStep type="groovy" name="Start Mock Service" id="ba0adc8e-d92f-4ca2-abce-30c246fe6789"><con:settings/><con:config><script>// Verify BatchListNotification Mock Service is NOT running
+if(testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner() != null) {
+
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) BatchListNotification Mock Service is running!");
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) Stopping BatchListNotification Mock Service!");
+	testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner().stop();
+	
+}
+
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mockervice");
 
 service.setPropertyValue("rxNotificationBody","");
 
-def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1").start();
+def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service").start();
 context.mockRunner = runner;
 
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Request DataCustodian to issue Notification message with ApplicationInformation Information" id="cc4851f3-ddd2-4685-9ea5-5c08d3c2e79e"><con:settings/><con:config><script>def ui = com.eviware.soapui.support.UISupport;
@@ -44199,11 +44243,20 @@ return;
 	</con:testCase>
 	<con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="PSH002 [POS] Notification Push/POST to ThirdParty of Authorization" searchProperties="true" id="2f1a77ef-80d6-49ed-9cca-b62f1ba05f02">
 		<con:settings/>
-		<con:testStep type="groovy" name="Start Mock Service" id="2f13d6a2-ccc7-4daf-b4e2-15442dfa9ff4"><con:settings/><con:config><script>def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+		<con:testStep type="groovy" name="Start Mock Service" id="2f13d6a2-ccc7-4daf-b4e2-15442dfa9ff4"><con:settings/><con:config><script>// Verify BatchListNotification Mock Service is NOT running
+if(testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner() != null) {
+
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) BatchListNotification Mock Service is running!");
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) Stopping BatchListNotification Mock Service!");
+	testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner().stop();
+	
+}
+
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 service.setPropertyValue("rxNotificationBody","");
 
-def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1").start();
+def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service").start();
 context.mockRunner = runner;
 
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Request DataCustodian to issue Notification message with Authorization Information" id="4026626f-c83c-49f3-8538-a9b905dd5b28"><con:settings/><con:config><script>
@@ -44518,11 +44571,20 @@ return;
 </script></con:config></con:testStep><con:testStep type="groovy" name="Done" id="90591cc7-1350-4c9d-8d4a-5831827c38a5"><con:settings/><con:config><script/></con:config></con:testStep><con:setupScript>log.info "===== Start TestCase  =====> " + context.testCase.getLabel()</con:setupScript><con:tearDownScript>log.info "===== "+ testRunner.status.toString() +" TestCase  =====> "  +  context.testCase.getLabel();</con:tearDownScript><con:properties/>
 	</con:testCase><con:testCase failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="PSH003 [POS] Notification Push/POST to ThirdParty of Subscription" searchProperties="true" id="cc71647f-cc55-4914-bde1-6adfa59d0e44">
 		<con:settings/>
-		<con:testStep type="groovy" name="Start Mock Service" id="96fac0e2-e0ef-4ac0-a9dd-2f3099c1576d"><con:settings/><con:config><script>def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+		<con:testStep type="groovy" name="Start Mock Service" id="96fac0e2-e0ef-4ac0-a9dd-2f3099c1576d"><con:settings/><con:config><script>// Verify BatchListNotification Mock Service is NOT running
+if(testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner() != null) {
+
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) BatchListNotification Mock Service is running!");
+	log.info("[FB_34] SFTP for bulk (Start Mock Service) Stopping BatchListNotification Mock Service!");
+	testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNotification").getMockRunner().stop();
+	
+}
+
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 service.setPropertyValue("rxNotificationBody","");
 
-def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1").start();
+def runner = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service").start();
 context.mockRunner = runner;
 
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Request DataCustodian to issue Notification message with Subscription Information" id="b4655dc6-de32-4751-93ea-ff5d374b7982"><con:settings/><con:config><script>
@@ -45857,7 +45919,7 @@ if(results == true) {
 else {
 	log.info "===== FAILED End   TestSuite =====> " + testSuite.name
 }
-</con:tearDownScript></con:testSuite><con:testSuite id="777829b5-238f-498b-8fca-fc91f28b2179" name="[FUTURE]*[FB_46] Core RetailCustomer"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="e6e692e4-a3af-493f-879e-e29d98472396" name="[FUTURE]*[FB_47] REST for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="134c0d4e-41b7-43ef-99a7-82910fc15181" name="[FUTURE]*[FB_48] SFTP for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="5f220152-b482-4fe6-a93c-c86983aa59ab" name="[FUTURE]*[FB_49] RetailCustomer Management REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="a4cad8a6-a545-43a7-813d-41f895c2ba75" name="[FUTURE]*[FB_50] RetailCustomer Resource Level REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty Notification REST MockService 1" docroot="" id="44aa183e-c020-4e6b-8402-539544493841"><con:settings/><con:startScript>context.mockService.setPropertyValue("rxNotificationBody","");</con:startScript><con:properties><con:property><con:name>rxNotificationBody</con:name><con:value/></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:onRequestScript/><con:restMockAction name="/ThirdParty/espi/1_1/Notification" method="POST" resourcePath="/ThirdParty/espi/1_1/Notification" id="6b6053c9-2c1a-4384-9b10-782eb51bbd4c"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>if(requestContext.mockService.getPropertyValue("rxNotificationBody")!= "") {
+</con:tearDownScript></con:testSuite><con:testSuite id="777829b5-238f-498b-8fca-fc91f28b2179" name="[FUTURE]*[FB_46] Core RetailCustomer"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="e6e692e4-a3af-493f-879e-e29d98472396" name="[FUTURE]*[FB_47] REST for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="134c0d4e-41b7-43ef-99a7-82910fc15181" name="[FUTURE]*[FB_48] SFTP for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="5f220152-b482-4fe6-a93c-c86983aa59ab" name="[FUTURE]*[FB_49] RetailCustomer Management REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="a4cad8a6-a545-43a7-813d-41f895c2ba75" name="[FUTURE]*[FB_50] RetailCustomer Resource Level REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty Notification Mock Service" docroot="" id="44aa183e-c020-4e6b-8402-539544493841"><con:settings/><con:startScript>context.mockService.setPropertyValue("rxNotificationBody","");</con:startScript><con:properties><con:property><con:name>rxNotificationBody</con:name><con:value/></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:onRequestScript/><con:restMockAction name="/ThirdParty/espi/1_1/Notification" method="POST" resourcePath="/ThirdParty/espi/1_1/Notification" id="6b6053c9-2c1a-4384-9b10-782eb51bbd4c"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>if(requestContext.mockService.getPropertyValue("rxNotificationBody")!= "") {
 	log.info("ThirdParty Notification REST MockService 1 (/ThirdParty/espi/1_1/Notification) Discarding additional notifications");
 	return;	
 }
@@ -45894,7 +45956,80 @@ requestContext.mockService.setPropertyValue("rxNotificationBody",strBody);
 
 
 
-</con:dispatchPath><con:response name="ThirdParty Notification REST Mock Service 1 /ThirdParty/espi/1_1/Notification POST Response" httpResponseStatus="200" id="31e9433f-70db-4381-8f38-75ff01ad0a7e"><con:settings/><con:script/><con:responseContent/></con:response></con:restMockAction></con:restMockService>
+</con:dispatchPath><con:response name="ThirdParty Notification REST Mock Service 1 /ThirdParty/espi/1_1/Notification POST Response" httpResponseStatus="200" id="31e9433f-70db-4381-8f38-75ff01ad0a7e"><con:settings/><con:script/><con:responseContent/></con:response></con:restMockAction><con:restMockAction name="/" method="GET" resourcePath="/" id="5a6ddb17-a1a1-4854-9b9f-6266343a355f"><con:settings/><con:defaultResponse>Diagnostic Response</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+// Script dispatcher is used to select a response based on the incoming request.
+// Here are few examples showing how to match based on path, query param, header and body
+
+// Match based on path
+def requestPath = mockRequest.getPath()
+log.info "Path: "+ requestPath
+
+if( requestPath.contains("json") )
+{
+    // return the name of the response you want to dispatch
+    return "JSON Response"
+}
+
+
+// Match based on query parameter
+def queryString = mockRequest.getRequest().getQueryString()
+log.info "QueryString: " + queryString
+
+if( queryString.contains("stockholm") )
+{
+    // return the name of the response you want to dispatch
+    return "Response Stockholm"
+}
+else if( queryString.contains("london") )
+{
+    // return the name of the response you want to dispatch
+    return "Response London"
+}
+
+
+// Match based on header
+def acceptEncodingHeaderList = mockRequest.getRequestHeaders().get("Accept-Encoding")
+log.info "AcceptEncoding Header List: " + acceptEncodingHeaderList
+
+if( acceptEncodingHeaderList.contains("gzip,deflate") )
+{
+    // return the name of the response you want to dispatch
+    return "GZiped Response"
+}
+
+
+// Match based on body
+def requestBody = mockRequest.getRequestContent()
+log.info "Request body: " + requestBody
+
+if( requestBody.contains("some data") )
+{
+    // return the name of the response you want to dispatch
+    return "Response N"
+}
+*/
+</con:dispatchPath><con:response name="Diagnostic Response" id="3b084363-4364-455a-8e61-ca73b0464d5d" httpResponseStatus="200"><con:settings/><con:script>import com.eviware.soapui.impl.wsdl.support.http.HttpClientSupport;
+import org.apache.commons.httpclient.Header;
+
+def String strRequestMethod;
+def String strRequestPath;
+def String strContent;
+
+log.info("ThirdParty Notification REST MockService (GET /Diagnostic Response)");
+
+// Obtain HttpRequest Method
+strRequestMethod = mockRequest.method;
+log.info("ThirdParty Notification REST MockService (GET /Diagnostic Response) Request Method: " + strRequestMethod);
+
+// Obtain HttpRequest Path
+strRequestPath = mockRequest.getPath();
+log.info("ThirdParty Notification REST MockService (GET /Diagnostic Response) Request Path: " + strRequestPath);
+
+// Obtain HttpRequest Content
+strContent = mockRequest.requestContent;
+log.info("ThirdParty Notification REST MockService (GET /Diagnostic Response) Request Content: " + strContent);
+
+</con:script><con:responseContent/></con:response></con:restMockAction></con:restMockService>
 <con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty Authorization Mock Service" docroot="" id="3a34ffc3-4858-4237-a55a-0cc1f8544c4a"><con:settings/><con:properties><con:property><con:name>tokenResponse</con:name><con:value/></con:property><con:property><con:name>SelectedScope</con:name><con:value>scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>DataCustodianAuthorizeQry</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_6_7_8_9_10_11_29_12_13_14_15_16_17_18_19_27_28_32_33_34_35_37_38_39_40_41_44;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;DataCustodianID=data_custodian</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>GotFirstRedirect</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>ExtractedSessionID</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>GotScopeSelPOST</con:name><con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></con:property><con:property><con:name>error</con:name><con:value>error=access_denied&amp;error_description=User%20denied%20access&amp;state=ee148ec2-9892-466e-a013-4dedf1eb3018</con:value></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>client_secret</con:name><con:value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">secret</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>state</con:name><con:value>ee148ec2-9892-466e-a013-4dedf1eb3018</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:restMockAction name="/ThirdParty/RetailCustomer/ScopeSelection" method="GET" resourcePath="/ThirdParty/RetailCustomer/ScopeSelection" id="a19f663e-daf5-4eab-bc7c-0fb638c2496d"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
 // Examples showing how to match based on path, query param and header
 // Match based on path
@@ -46287,6 +46422,79 @@ def httpResponse = mockRequest.httpResponse
 httpResponse.addHeader("Location",strRespLoc);
 
 
+
+</con:script><con:responseContent/></con:response></con:restMockAction><con:restMockAction name="/" method="GET" resourcePath="/" id="ee91990b-5164-4d32-8790-920061b4a375"><con:settings/><con:defaultResponse>Diagnostic Response</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+// Script dispatcher is used to select a response based on the incoming request.
+// Here are few examples showing how to match based on path, query param, header and body
+
+// Match based on path
+def requestPath = mockRequest.getPath()
+log.info "Path: "+ requestPath
+
+if( requestPath.contains("json") )
+{
+    // return the name of the response you want to dispatch
+    return "JSON Response"
+}
+
+
+// Match based on query parameter
+def queryString = mockRequest.getRequest().getQueryString()
+log.info "QueryString: " + queryString
+
+if( queryString.contains("stockholm") )
+{
+    // return the name of the response you want to dispatch
+    return "Response Stockholm"
+}
+else if( queryString.contains("london") )
+{
+    // return the name of the response you want to dispatch
+    return "Response London"
+}
+
+
+// Match based on header
+def acceptEncodingHeaderList = mockRequest.getRequestHeaders().get("Accept-Encoding")
+log.info "AcceptEncoding Header List: " + acceptEncodingHeaderList
+
+if( acceptEncodingHeaderList.contains("gzip,deflate") )
+{
+    // return the name of the response you want to dispatch
+    return "GZiped Response"
+}
+
+
+// Match based on body
+def requestBody = mockRequest.getRequestContent()
+log.info "Request body: " + requestBody
+
+if( requestBody.contains("some data") )
+{
+    // return the name of the response you want to dispatch
+    return "Response N"
+}
+*/
+</con:dispatchPath><con:response name="Diagnostic Response" id="7525a88a-473f-48ad-9d1c-034796ae1fb9" httpResponseStatus="200"><con:settings/><con:script>import com.eviware.soapui.impl.wsdl.support.http.HttpClientSupport;
+import org.apache.commons.httpclient.Header;
+
+def String strRequestMethod;
+def String strRequestPath;
+def String strContent;
+
+log.info("ThirdParty Authorization Mock Service (GET /Diagnostic Response)");
+
+// Obtain HttpRequest Method
+strRequestMethod = mockRequest.method;
+log.info("ThirdParty Authorization Mock Service (GET /Diagnostic Response) Request Method: " + strRequestMethod);
+
+// Obtain HttpRequest Path
+strRequestPath = mockRequest.getPath();
+log.info("ThirdParty Authorization Mock Service (GET /Diagnostic Response) Request Path: " + strRequestPath);
+
+// Obtain HttpRequest Content
+strContent = mockRequest.requestContent;
+log.info("ThirdParty Authorization Mock Service (GET /Diagnostic Response) Request Content: " + strContent);
 
 </con:script><con:responseContent/></con:response></con:restMockAction></con:restMockService>
 <con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty NEG A tests Authorization Mock Service" docroot="" id="cdc5ffa6-a930-460a-b724-42e8e7d73f4f"><con:settings/><con:properties><con:property><con:name>tokenResponse</con:name><con:value/></con:property><con:property><con:name>SelectedScope</con:name><con:value>scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>DataCustodianAuthorizeQry</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_6_7_8_9_10_11_29_12_13_14_15_16_17_18_19_27_28_32_33_34_35_37_38_39_40_41_44;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;DataCustodianID=data_custodian</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>GotFirstRedirect</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>GotScopeSelPOST</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>client_secret</con:name><con:value>secret</con:value></con:property><con:property><con:name>state</con:name><con:value>ee148ec2-9892-466e-a013-4dedf1eb3018</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:onRequestScript/><con:restMockAction name="/ThirdParty/RetailCustomer/ScopeSelection" method="GET" resourcePath="/ThirdParty/RetailCustomer/ScopeSelection" id="fbe0856f-dd44-4b04-8b84-d08a490ece57"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
@@ -46731,7 +46939,7 @@ Please select <strong>"<i>OK</>"</strong> on SoapUI dialog box.
 <br><br>
 </body>
 </html>
-]]></con:responseContent></con:response></con:restMockAction><con:restMockAction name="/" method="GET" resourcePath="/" id="ccb4267e-4aa4-4e34-a765-84d6fbe324ce"><con:settings/><con:defaultResponse>Default Response</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+]]></con:responseContent></con:response></con:restMockAction><con:restMockAction name="/" method="GET" resourcePath="/" id="ccb4267e-4aa4-4e34-a765-84d6fbe324ce"><con:settings/><con:defaultResponse>Diagnostic Response</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
 // Script dispatcher is used to select a response based on the incoming request.
 // Here are few examples showing how to match based on path, query param, header and body
 
@@ -46783,23 +46991,29 @@ if( requestBody.contains("some data") )
     return "Response N"
 }
 */
-</con:dispatchPath><con:response name="Default Response" id="cb684cee-034d-471c-a299-56bb290c0d93" httpResponseStatus="200"><con:settings/><con:script>import com.eviware.soapui.impl.wsdl.support.http.HttpClientSupport;
+</con:dispatchPath><con:response name="Diagnostic Response" id="cb684cee-034d-471c-a299-56bb290c0d93" httpResponseStatus="200"><con:settings/><con:script>import com.eviware.soapui.impl.wsdl.support.http.HttpClientSupport;
 import org.apache.commons.httpclient.Header;
 
 def String strRequestMethod;
 def String strRequestPath;
+def String strContent;
 
-log.info("ThirdParty NEG A tests Authorization Mock Service (GET /Default Response) Started");
+log.info("ThirdParty NEG A tests Authorization Mock Service (GET / (Diagnostic Response)");
 
 // Obtain HttpRequest Method
 strRequestMethod = mockRequest.method;
-log.info("ThirdParty NEG A tests Authorization Mock Service (GET /Default Response) Request Method: " + strRequestMethod);
+log.info("ThirdParty NEG A tests Authorization Mock Service (GET /Diagnostic Response) Request Method: " + strRequestMethod);
 
 // Obtain HttpRequest Path
 strRequestPath = mockRequest.getPath();
-log.info("ThirdParty NEG A tests Authorization Mock Service (GET /Default Response) Request Path: " + strRequestPath);
+log.info("ThirdParty NEG A tests Authorization Mock Service (GET /Diagnostic Response) Request Path: " + strRequestPath);
+
+// Obtain HttpRequest Content
+strContent = mockRequest.requestContent;
+log.info("ThirdParty NEG A tests Authorization Mock Service (GET /Diagnostic Response) Request Content: " + strContent);
+
 </con:script><con:responseContent/></con:response></con:restMockAction></con:restMockService>
-<con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty NEG B tests Authorization Mock Service" docroot="" id="f53ba382-c35f-4ef1-901a-f07c7855c1b3"><con:settings/><con:properties><con:property><con:name>tokenResponse</con:name><con:value/></con:property><con:property><con:name>SelectedScope</con:name><con:value>scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>DataCustodianAuthorizeQry</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_6_7_8_9_10_11_29_12_13_14_15_16_17_18_19_27_28_32_33_34_35_37_38_39_40_41_44;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;DataCustodianID=data_custodian</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value>9C0B4BBAD2FBDAF475058F4996FE725B</con:value></con:property><con:property><con:name>GotFirstRedirect</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>ExtractedSessionID</con:name><con:value>FALSE</con:value></con:property><con:property><con:name>GotScopeSelPOST</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value>JCr2YO</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>client_secret</con:name><con:value>secret</con:value></con:property><con:property><con:name>state</con:name><con:value>ee148ec2-9892-466e-a013-4dedf1eb3018</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:restMockAction name="/ThirdParty/RetailCustomer/ScopeSelection" method="GET" resourcePath="/ThirdParty/RetailCustomer/ScopeSelection" id="80ce918e-62e8-4eb0-881e-fe7226c68892"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+<con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty NEG B tests Authorization Mock Service" docroot="" id="f53ba382-c35f-4ef1-901a-f07c7855c1b3"><con:settings/><con:properties><con:property><con:name>tokenResponse</con:name><con:value/></con:property><con:property><con:name>SelectedScope</con:name><con:value>scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property><con:name>DataCustodianAuthorizeQry</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13&amp;scope=FB=1_3_4_5_6_7_8_9_10_11_29_12_13_14_15_16_17_18_19_27_28_32_33_34_35_37_38_39_40_41_44;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13&amp;DataCustodianID=data_custodian</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>redirect_uri</con:name><con:value>https://localhost:8444/ThirdParty/espi/1_1/OAuthCallBack</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>browserSession</con:name><con:value>9C0B4BBAD2FBDAF475058F4996FE725B</con:value></con:property><con:property><con:name>GotFirstRedirect</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>ExtractedSessionID</con:name><con:value>FALSE</con:value></con:property><con:property><con:name>GotScopeSelPOST</con:name><con:value>TRUE</con:value></con:property><con:property><con:name>OAuthCodeReceivedValue</con:name><con:value>KAGFF3</con:value></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>client_id</con:name><con:value>surface_tp</con:value></con:property><con:property><con:name>dataCustodianScopeSelectionScreenURI</con:name><con:value>https://localhost:8443/DataCustodian/RetailCustomer/ScopeSelectionList?ThirdPartyID=surface_tp</con:value></con:property><con:property><con:name>client_secret</con:name><con:value>secret</con:value></con:property><con:property><con:name>state</con:name><con:value>ee148ec2-9892-466e-a013-4dedf1eb3018</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:restMockAction name="/ThirdParty/RetailCustomer/ScopeSelection" method="GET" resourcePath="/ThirdParty/RetailCustomer/ScopeSelection" id="80ce918e-62e8-4eb0-881e-fe7226c68892"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
 // Examples showing how to match based on path, query param and header
 // Match based on path
 def requestPath = mockRequest.getPath()
@@ -47103,6 +47317,79 @@ httpResponse.addHeader("Location",strRespLoc);
 
 
 
+</con:script><con:responseContent/></con:response></con:restMockAction><con:restMockAction name="/" method="GET" resourcePath="/" id="ab36bd07-fd25-45e1-b6be-e61b2a9c87ec"><con:settings/><con:defaultResponse>Diagnostic Response</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+// Script dispatcher is used to select a response based on the incoming request.
+// Here are few examples showing how to match based on path, query param, header and body
+
+// Match based on path
+def requestPath = mockRequest.getPath()
+log.info "Path: "+ requestPath
+
+if( requestPath.contains("json") )
+{
+    // return the name of the response you want to dispatch
+    return "JSON Response"
+}
+
+
+// Match based on query parameter
+def queryString = mockRequest.getRequest().getQueryString()
+log.info "QueryString: " + queryString
+
+if( queryString.contains("stockholm") )
+{
+    // return the name of the response you want to dispatch
+    return "Response Stockholm"
+}
+else if( queryString.contains("london") )
+{
+    // return the name of the response you want to dispatch
+    return "Response London"
+}
+
+
+// Match based on header
+def acceptEncodingHeaderList = mockRequest.getRequestHeaders().get("Accept-Encoding")
+log.info "AcceptEncoding Header List: " + acceptEncodingHeaderList
+
+if( acceptEncodingHeaderList.contains("gzip,deflate") )
+{
+    // return the name of the response you want to dispatch
+    return "GZiped Response"
+}
+
+
+// Match based on body
+def requestBody = mockRequest.getRequestContent()
+log.info "Request body: " + requestBody
+
+if( requestBody.contains("some data") )
+{
+    // return the name of the response you want to dispatch
+    return "Response N"
+}
+*/
+</con:dispatchPath><con:response name="Diagnostic Response" id="86a9f664-88ec-4da6-84ea-a7e0a9781d40" httpResponseStatus="200"><con:settings/><con:script>import com.eviware.soapui.impl.wsdl.support.http.HttpClientSupport;
+import org.apache.commons.httpclient.Header;
+
+def String strRequestMethod;
+def String strRequestPath;
+def String strContent;
+
+log.info("ThirdParty NEG B tests Authorization Mock Service (GET /Diagnostic Response)");
+
+// Obtain HttpRequest Method
+strRequestMethod = mockRequest.method;
+log.info("ThirdParty NEG B tests Authorization Mock Service (GET /Diagnostic Response) Request Method: " + strRequestMethod);
+
+// Obtain HttpRequest Path
+strRequestPath = mockRequest.getPath();
+log.info("ThirdParty NEG B tests Authorization Mock Service (GET /Diagnostic Response) Request Path: " + strRequestPath);
+
+// Obtain HttpRequest Content
+strContent = mockRequest.requestContent;
+log.info("ThirdParty NEG B tests Authorization Mock Service (GET /Diagnostic Response) Request Content: " + strContent);
+
 </con:script><con:responseContent/></con:response></con:restMockAction></con:restMockService>
 <con:restMockService id="d3128334-cd5f-4524-9c93-39bbc43838cf" port="8081" path="/" host="openespivm" name="BatchListNotification" docroot=""><con:settings/><con:startScript/><con:properties><con:property><con:name>BatchList</con:name><con:value/></con:property></con:properties><con:restMockAction name="/ThirdParty/espi/1_1/Notification" method="POST" resourcePath="/ThirdParty/espi/1_1/Notification" id="c8109651-384d-4374-8e42-2054b7258aab"><con:settings/><con:defaultResponse>/ThirdParty/espi/1_1/Notification POST Response</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>// Store batch list in project for use by foreground script
 def project = requestContext.mockService.mockRunner.getMockService().getProject()
@@ -47111,7 +47398,80 @@ def requestBody = mockRequest.getRequestContent()
 log.info "BatchListNotification (/ThirdParty/espi/1_1/Notification) RX: POST Request body: " + requestBody
 //project.setPropertyValue("BatchList",requestBody);
 requestContext.mockService.setPropertyValue("BatchList",requestBody);
-</con:dispatchPath><con:response name="/ThirdParty/espi/1_1/Notification POST Response" id="80857bf2-7556-45dc-8c55-7bdcead30356" httpResponseStatus="200"><con:settings/><con:responseContent/></con:response></con:restMockAction></con:restMockService><con:restMockService id="d62e7b55-3326-4548-8946-7bb2de29e18b" port="8081" path="/" host="openespivm" name="REST MockService for STunnel" docroot=""><con:settings/><con:properties/><con:restMockAction name="/" method="GET" resourcePath="/" id="fc1cb170-728b-46d7-8b01-0dd2f47aaf2c"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+</con:dispatchPath><con:response name="/ThirdParty/espi/1_1/Notification POST Response" id="80857bf2-7556-45dc-8c55-7bdcead30356" httpResponseStatus="200"><con:settings/><con:responseContent/></con:response></con:restMockAction><con:restMockAction name="/" method="GET" resourcePath="/" id="7cfbf564-c29d-4b99-806a-5de209432b5c"><con:settings/><con:defaultResponse>Diagnostic Response</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+// Script dispatcher is used to select a response based on the incoming request.
+// Here are few examples showing how to match based on path, query param, header and body
+
+// Match based on path
+def requestPath = mockRequest.getPath()
+log.info "Path: "+ requestPath
+
+if( requestPath.contains("json") )
+{
+    // return the name of the response you want to dispatch
+    return "JSON Response"
+}
+
+
+// Match based on query parameter
+def queryString = mockRequest.getRequest().getQueryString()
+log.info "QueryString: " + queryString
+
+if( queryString.contains("stockholm") )
+{
+    // return the name of the response you want to dispatch
+    return "Response Stockholm"
+}
+else if( queryString.contains("london") )
+{
+    // return the name of the response you want to dispatch
+    return "Response London"
+}
+
+
+// Match based on header
+def acceptEncodingHeaderList = mockRequest.getRequestHeaders().get("Accept-Encoding")
+log.info "AcceptEncoding Header List: " + acceptEncodingHeaderList
+
+if( acceptEncodingHeaderList.contains("gzip,deflate") )
+{
+    // return the name of the response you want to dispatch
+    return "GZiped Response"
+}
+
+
+// Match based on body
+def requestBody = mockRequest.getRequestContent()
+log.info "Request body: " + requestBody
+
+if( requestBody.contains("some data") )
+{
+    // return the name of the response you want to dispatch
+    return "Response N"
+}
+*/
+</con:dispatchPath><con:response name="Diagnostic Response" id="5b04675e-7056-4001-8884-1a0162930b43" httpResponseStatus="200"><con:settings/><con:script>import com.eviware.soapui.impl.wsdl.support.http.HttpClientSupport;
+import org.apache.commons.httpclient.Header;
+
+def String strRequestMethod;
+def String strRequestPath;
+def String strContent;
+
+log.info("BatchListNotification Mock Service (GET /Diagnostic Response)");
+
+// Obtain HttpRequest Method
+strRequestMethod = mockRequest.method;
+log.info("BatchListNotification Mock Service (GET /Diagnostic Response) Request Method: " + strRequestMethod);
+
+// Obtain HttpRequest Path
+strRequestPath = mockRequest.getPath();
+log.info("BatchListNotification Mock Service (GET /Diagnostic Response) Request Path: " + strRequestPath);
+
+// Obtain HttpRequest Content
+strContent = mockRequest.requestContent;
+log.info("BatchListNotification Mock Service (GET /Diagnostic Response) Request Content: " + strContent);
+
+</con:script><con:responseContent/></con:response></con:restMockAction></con:restMockService><con:restMockService id="d62e7b55-3326-4548-8946-7bb2de29e18b" port="8081" path="/" host="openespivm" name="REST MockService for STunnel" docroot=""><con:settings/><con:properties/><con:restMockAction name="/" method="GET" resourcePath="/" id="fc1cb170-728b-46d7-8b01-0dd2f47aaf2c"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
 // Script dispatcher is used to select a response based on the incoming request.
 // Here are few examples showing how to match based on path, query param, header and body
 
@@ -47774,7 +48134,7 @@ if( requestBody.contains("some data") )
 */
 </con:dispatchPath><con:response name="Response 1 - 202" id="552f9a94-4650-43b2-b2a0-f0aa02f07719" httpResponseStatus="202"><con:settings/><con:responseContent/></con:response></con:restMockAction></con:restMockService><con:properties>
 
-	<con:property><con:name>access_token</con:name><con:value>a6571ea4-9fde-45dc-a8b5-47d0b959414a</con:value></con:property><con:property><con:name>applicationInformationId</con:name><con:value>4</con:value></con:property><con:property><con:name>authorizationId</con:name><con:value>6</con:value></con:property><con:property><con:name>authorizationServer</con:name><con:value>localhost:8443</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property>
+	<con:property><con:name>access_token</con:name><con:value>45a4f829-e9cb-49c8-b16e-12b31dff1bb8</con:value></con:property><con:property><con:name>applicationInformationId</con:name><con:value>4</con:value></con:property><con:property><con:name>authorizationId</con:name><con:value>6</con:value></con:property><con:property><con:name>authorizationServer</con:name><con:value>localhost:8443</con:value></con:property><con:property><con:name>authorizationServerAuthorizationEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/authorize</con:value></con:property><con:property><con:name>authorizationServerTokenEndpoint</con:name><con:value>https://localhost:8443/DataCustodian/oauth/token</con:value></con:property><con:property><con:name>authorizationURI</con:name><con:value>scope=FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13</con:value></con:property><con:property>
 
 		<con:name>BaseURL</con:name>
 		<con:value/>
@@ -47789,7 +48149,7 @@ if( requestBody.contains("some data") )
 	
 	
 	
-	<con:property><con:name>bulkId</con:name><con:value>1</con:value></con:property><con:property><con:name>certScopes</con:name><con:value>FB=1_4_5_15</con:value></con:property><con:property><con:name>client_access_token</con:name><con:value>48fd9d43-1bb4-4f05-b196-0501a8130f07</con:value></con:property>
+	<con:property><con:name>bulkId</con:name><con:value>1</con:value></con:property><con:property><con:name>certScopes</con:name><con:value>FB=1_4_5_15</con:value></con:property><con:property><con:name>client_access_token</con:name><con:value>98d61eaa-e469-4dd0-81e6-452c09e48837</con:value></con:property>
 	
 	
 	
@@ -47817,7 +48177,7 @@ if( requestBody.contains("some data") )
 	
 	
 	
-	<con:property><con:name>readingTypeId</con:name><con:value>1</con:value></con:property><con:property><con:name>registration_access_token</con:name><con:value>4df9fbc0-0841-4b2a-825d-7eaa7936420d</con:value></con:property><con:property><con:name>registration_third_party_access_token</con:name><con:value>c66b0854-ea1f-4e24-afb7-afab9e0f6c5e</con:value></con:property><con:property><con:name>resourceId</con:name><con:value>01</con:value></con:property><con:property><con:name>resourceServer</con:name><con:value>localhost:8443</con:value></con:property><con:property><con:name>resourceServerUri</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource</con:value></con:property><con:property><con:name>resourceUri</con:name><con:value>espi/1_1/resource</con:value></con:property>
+	<con:property><con:name>readingTypeId</con:name><con:value>1</con:value></con:property><con:property><con:name>registration_access_token</con:name><con:value>6bf8626f-fbe9-4a63-a1cd-08f80f495f3f</con:value></con:property><con:property><con:name>registration_third_party_access_token</con:name><con:value>c66b0854-ea1f-4e24-afb7-afab9e0f6c5e</con:value></con:property><con:property><con:name>resourceId</con:name><con:value>01</con:value></con:property><con:property><con:name>resourceServer</con:name><con:value>localhost:8443</con:value></con:property><con:property><con:name>resourceServerUri</con:name><con:value>https://localhost:8443/DataCustodian/espi/1_1/resource</con:value></con:property><con:property><con:name>resourceUri</con:name><con:value>espi/1_1/resource</con:value></con:property>
 	
 	
 	


### PR DESCRIPTION
1) Rename 'ThirdParty Notification REST MockService 1' to 'ThirdParty Notification Mock Service'
2) Update Test Step 'Start Mock Service' in Test Suites [FB_34] SFTP for bulk, [FB_35] REST for bulk, 
    and [FB_39] PUSH Model to use new 'ThirdParty Notification Mock Service' name
3) Add logic to Test Step 'Start Mock Service' in Test Suites [FB_35] SFTP for bulk, [FB_35] REST for 
    bulk, and [FB_39] Push Model to test if 'BatchListNotification' Mock Service is running and stop it
    before starting 'ThirdParty Notification Mock Service'