### PR TITLE
Miscellaneous updates to correct issue causing SoapUI test harness to hang due to multiple mock services running on the same port

### DIFF
--- a/SOAPUI/GBCMD-soapui-project.xml
+++ b/SOAPUI/GBCMD-soapui-project.xml
@@ -42413,7 +42413,7 @@ return;</script></con:config></con:testStep><con:testStep type="manualTestStep" 
 After the notification is issued please indicate "Pass" on this test step "test status" and click OK.
 </con:description><con:settings/><con:config xsi:type="con:ManualTestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:expectedResult>Pass</con:expectedResult></con:config></con:testStep><con:testStep type="groovy" name="Stop Mock Service" id="3bf4597e-4be1-41d2-b9da-25226da0afd4"><con:settings/><con:config><script>context.mockRunner.stop();
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Validate notification" id="53db505d-7657-4c7e-8205-3361a765ff45"><con:settings/><con:config><script>def groovyUtils = new com.eviware.soapui.support.GroovyUtils( context );
-def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 String strNotificationBody =  service.getPropertyValue("rxNotificationBody");
 log.info("notification Body:" + strNotificationBody);
@@ -42854,7 +42854,7 @@ if(result==false) {
 
 assert true;</script></con:config></con:testStep><con:testStep type="groovy" name="Stop Mock Service" id="05af9309-ea0c-45a6-8fd2-ca30afe7e725"><con:settings/><con:config><script>context.mockRunner.stop();
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Validate notification" id="b434360f-a30a-4f31-ba44-5d61211fe1e9"><con:settings/><con:config><script>def groovyUtils = new com.eviware.soapui.support.GroovyUtils( context );
-def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 String strNotificationBody =  service.getPropertyValue("rxNotificationBody");
 log.info("RBK001 [POS] REST for BULK notification - authorized GET access (Validate notification) notification Body:" + strNotificationBody);
@@ -43191,7 +43191,7 @@ if(result==false) {
 
 assert true;</script></con:config></con:testStep><con:testStep type="groovy" name="Stop Mock Service" id="98839fcf-70e0-43d0-9205-01640cdb83eb"><con:settings/><con:config><script>context.mockRunner.stop();
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Validate notification" id="30404ab7-cc97-47e3-9bdb-45b1ddc9ad8c"><con:settings/><con:config><script>def groovyUtils = new com.eviware.soapui.support.GroovyUtils( context );
-def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 String strNotificationBody =  service.getPropertyValue("rxNotificationBody");
 
@@ -43913,7 +43913,7 @@ if(testRunner.testCase.testSuite.project.getRestMockServiceByName("BatchListNoti
 	
 }
 
-def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mockervice");
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 service.setPropertyValue("rxNotificationBody","");
 
@@ -43937,7 +43937,7 @@ if(result==false) {
 
 assert true;</script></con:config></con:testStep><con:testStep type="groovy" name="Stop Mock Service" id="668ef150-7aad-4d43-8629-f7a8be0356d9"><con:settings/><con:config><script>context.mockRunner.stop();
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Validate notification and dispatch GET or SFTP step" id="acbacd7e-5f06-4670-aba1-49ecdbf19def"><con:settings/><con:config><script>def groovyUtils = new com.eviware.soapui.support.GroovyUtils( context );
-def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 String strNotificationBody =  service.getPropertyValue("rxNotificationBody");
 log.info("PSH001 [POS] Notification Push/POST to ThirdParty of ApplicationInformation -- (Validate notification and dispatch GET or SFTP step) Notification Body: " + strNotificationBody);
@@ -44159,7 +44159,7 @@ if(list.size()>0){
 	cmdRm = 'rm ' + transferDir +  '/*';
 	
 	if(RunCommand(cmdRm) != true) {
-		log.info({PSH001 [POS] Notification Push/POST to ThirdParty of ApplicationInformation -- (Issue SFTP GET) could not clear transfer directory " + transferDir);
+		log.info("PSH001 [POS] Notification Push/POST to ThirdParty of ApplicationInformation -- (Issue SFTP GET) could not clear transfer directory " + transferDir);
 		log.error("PSH001 [POS] Notification Push/POST to ThirdParty of ApplicationInformation -- (Issue SFTP GET) could not clear transfer directory " + transferDir);
 		testRunner.fail("PSH001 [POS] Notification Push/POST to ThirdParty of ApplicationInformation -- (Issue SFTP GET) could not clear transfer directory " + transferDir);
 		return;
@@ -44278,7 +44278,7 @@ if(result==false) {
 
 assert true;</script></con:config></con:testStep><con:testStep type="groovy" name="Stop Mock Service" id="79e3684e-53f1-4fd5-8a56-c9dc78d25f07"><con:settings/><con:config><script>context.mockRunner.stop();
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Validate notification and dispatch GET or SFTP step" id="a48dc8fb-9e71-4634-8d26-2e035ff3c1f6"><con:settings/><con:config><script>def groovyUtils = new com.eviware.soapui.support.GroovyUtils( context );
-def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 String strNotificationBody =  service.getPropertyValue("rxNotificationBody");
 log.info("PSH002 [POS] Notification Push/POST to ThirdParty of Authorization -- (Validate notification and dispatch GET or SFTP step) Notification Body:" + strNotificationBody);
@@ -44606,7 +44606,7 @@ if(result==false) {
 
 assert true;</script></con:config></con:testStep><con:testStep type="groovy" name="Stop Mock Service" id="d1ec108d-f5fc-4fe3-8b46-7760f765df70"><con:settings/><con:config><script>context.mockRunner.stop();
 return;</script></con:config></con:testStep><con:testStep type="groovy" name="Validate notification and dispatch GET or SFTP step" id="e6f199fb-fcef-40a4-9415-74fc8b1adcaa"><con:settings/><con:config><script>def groovyUtils = new com.eviware.soapui.support.GroovyUtils( context );
-def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification REST MockService 1");
+def service = testRunner.testCase.testSuite.project.getRestMockServiceByName("ThirdParty Notification Mock Service");
 
 String strNotificationBody =  service.getPropertyValue("rxNotificationBody");
 log.info("PSH003 [POS] Notification Push/POST to ThirdParty of Subscription -- (Validate notification and dispatch GET or SFTP step) Notification Body:" + strNotificationBody);
@@ -45919,8 +45919,8 @@ if(results == true) {
 else {
 	log.info "===== FAILED End   TestSuite =====> " + testSuite.name
 }
-</con:tearDownScript></con:testSuite><con:testSuite id="777829b5-238f-498b-8fca-fc91f28b2179" name="[FUTURE]*[FB_46] Core RetailCustomer"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="e6e692e4-a3af-493f-879e-e29d98472396" name="[FUTURE]*[FB_47] REST for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="134c0d4e-41b7-43ef-99a7-82910fc15181" name="[FUTURE]*[FB_48] SFTP for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="5f220152-b482-4fe6-a93c-c86983aa59ab" name="[FUTURE]*[FB_49] RetailCustomer Management REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="a4cad8a6-a545-43a7-813d-41f895c2ba75" name="[FUTURE]*[FB_50] RetailCustomer Resource Level REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty Notification Mock Service" docroot="" id="44aa183e-c020-4e6b-8402-539544493841"><con:settings/><con:startScript>context.mockService.setPropertyValue("rxNotificationBody","");</con:startScript><con:properties><con:property><con:name>rxNotificationBody</con:name><con:value/></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:onRequestScript/><con:restMockAction name="/ThirdParty/espi/1_1/Notification" method="POST" resourcePath="/ThirdParty/espi/1_1/Notification" id="6b6053c9-2c1a-4384-9b10-782eb51bbd4c"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>if(requestContext.mockService.getPropertyValue("rxNotificationBody")!= "") {
-	log.info("ThirdParty Notification REST MockService 1 (/ThirdParty/espi/1_1/Notification) Discarding additional notifications");
+</con:tearDownScript></con:testSuite><con:testSuite id="777829b5-238f-498b-8fca-fc91f28b2179" name="[FUTURE]*[FB_46] Core RetailCustomer"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="e6e692e4-a3af-493f-879e-e29d98472396" name="[FUTURE]*[FB_47] REST for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="134c0d4e-41b7-43ef-99a7-82910fc15181" name="[FUTURE]*[FB_48] SFTP for RetailCustomer Bulk"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="5f220152-b482-4fe6-a93c-c86983aa59ab" name="[FUTURE]*[FB_49] RetailCustomer Management REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:testSuite id="a4cad8a6-a545-43a7-813d-41f895c2ba75" name="[FUTURE]*[FB_50] RetailCustomer Resource Level REST"><con:settings/><con:runType>SEQUENTIAL</con:runType><con:properties/></con:testSuite><con:restMockService port="8081" path="/" host="openespivm" name="ThirdParty Notification Mock Service" docroot="" id="44aa183e-c020-4e6b-8402-539544493841"><con:settings/><con:startScript>context.mockService.setPropertyValue("rxNotificationBody","");</con:startScript><con:properties><con:property><con:name>rxNotificationBody</con:name><con:value/></con:property><con:property><con:name>mockPort</con:name><con:value>8081</con:value></con:property><con:property><con:name>proxyOutPort</con:name><con:value>8080</con:value></con:property><con:property><con:name>proxyOutPort1</con:name><con:value>8080</con:value></con:property></con:properties><con:onRequestScript/><con:restMockAction name="/ThirdParty/espi/1_1/Notification" method="POST" resourcePath="/ThirdParty/espi/1_1/Notification" id="6b6053c9-2c1a-4384-9b10-782eb51bbd4c"><con:settings/><con:defaultResponse>ThirdParty Notification Mock Service/ThirdParty/espi/1_1/Notification POST Response</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>if(requestContext.mockService.getPropertyValue("rxNotificationBody")!= "") {
+	log.info("ThirdParty Notification Mock Service (/ThirdParty/espi/1_1/Notification) Discarding additional notifications");
 	return;	
 }
 
@@ -45928,17 +45928,17 @@ String strBody = "";
 requestContext.mockService.setPropertyValue("rxNotificationBody",strBody);
 
 if(mockRequest.httpRequest.method != "POST") {
-	log.info("ThirdParty Notification REST MockService 1 (/ThirdParty/espi/1_1/Notification) Message other than POST received. Discarding");
+	log.info("ThirdParty Notification Mock Service (/ThirdParty/espi/1_1/Notification) Message other than POST received. Discarding");
 	return;
 }
 
 
 try {
 	str = mockRequest.getRequestContent();
-	log.info("ThirdParty Notification REST MockService 1 (/ThirdParty/espi/1_1/Notification) GetRequestContent: " + str);
+	log.info("ThirdParty Notification Mock Service (/ThirdParty/espi/1_1/Notification) GetRequestContent: " + str);
 
 	str.eachLine {line->
-		log.info "ThirdParty Notification REST MockService 1 (/ThirdParty/espi/1_1/Notification)  Line: " + line;
+		log.info "ThirdParty Notification Mock Service (/ThirdParty/espi/1_1/Notification)  Line: " + line;
 		strBody = strBody + line;
 	}
 
@@ -45946,17 +45946,17 @@ try {
 //		strBody = strBody + line;
 //	}
 
-	log.info("ThirdParty Notification REST MockService 1 (/ThirdParty/espi/1_1/Notification)  RX Notification POST Body:" + strBody);
+	log.info("ThirdParty Notification Mock Service (/ThirdParty/espi/1_1/Notification)  RX Notification POST Body:" + strBody);
        
   } catch (Exception e) {
-	log.error("ThirdParty Notification REST MockService 1 (/ThirdParty/espi/1_1/Notification)  Exception: " + e)
+	log.error("ThirdParty Notification Mock Service (/ThirdParty/espi/1_1/Notification)  Exception: " + e)
 }
 
 requestContext.mockService.setPropertyValue("rxNotificationBody",strBody);
 
 
 
-</con:dispatchPath><con:response name="ThirdParty Notification REST Mock Service 1 /ThirdParty/espi/1_1/Notification POST Response" httpResponseStatus="200" id="31e9433f-70db-4381-8f38-75ff01ad0a7e"><con:settings/><con:script/><con:responseContent/></con:response></con:restMockAction><con:restMockAction name="/" method="GET" resourcePath="/" id="5a6ddb17-a1a1-4854-9b9f-6266343a355f"><con:settings/><con:defaultResponse>Diagnostic Response</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
+</con:dispatchPath><con:response name="ThirdParty Notification Mock Service/ThirdParty/espi/1_1/Notification POST Response" httpResponseStatus="200" id="31e9433f-70db-4381-8f38-75ff01ad0a7e"><con:settings/><con:script/><con:responseContent/></con:response></con:restMockAction><con:restMockAction name="/" method="GET" resourcePath="/" id="5a6ddb17-a1a1-4854-9b9f-6266343a355f"><con:settings/><con:defaultResponse>Diagnostic Response</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:dispatchPath>/*
 // Script dispatcher is used to select a response based on the incoming request.
 // Here are few examples showing how to match based on path, query param, header and body
 


### PR DESCRIPTION
1) Update additional Test Steps in Test Suites [FB_34] SFTP for bulk, [FB_35] REST for bulk, and
    [FB_39] PUSH Model to use new 'ThirdParty Notification Mock Service' name
2) Rename REST response title in 'POST /ThirdParty/espi/1_1/Notification' response of 'ThirdParty 
    Notification Mock Service' to reflect renaming Mock Service, 3) Revise log.info messages in 'POST
    /ThirdParty/espi/1_1/Notification' response of 'ThirdParty Notification Mock Service' to reflect
    renaming Mock Service