### PR TITLE
Query parameter tests corrected to avoid local time conversions.

### DIFF
--- a/SOAPUI/etc/gbcmd_secure.conf
+++ b/SOAPUI/etc/gbcmd_secure.conf
@@ -6,6 +6,7 @@ ServiceEndpoint="https://localhost:8443/DataCustodian"
 DataCustodianContext="DataCustodian"
 ThirdPartyContext="ThirdParty"
 linkPrefixForReplace="https://localhost:8443/DataCustodian/"
+resourceURI="espi/1_1/resource"
 
 // test accounts
 TestManager="grace"

--- a/SOAPUI/etc/gbcmdcert_testcmdlocal.conf
+++ b/SOAPUI/etc/gbcmdcert_testcmdlocal.conf
@@ -1,0 +1,30 @@
+FileName="gbcmdcert.conf"
+
+// NAESB Purchased Standards Website		
+NAESBPurchasedStandardsURI="https://www.naesb.org//pdf2/copyright.pdf"		
+		
+// NIST FIPS 140-2 Certificate Website		
+NISTFIPSCertScreen="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm"
+
+// Test Harness Platform SSL Certificate and Private Key
+soapUIPlatformSSLCertificate="/etc/stunnel/greenbuttonalliance_ssl_certificate_2016_11_16.pem"
+soapUIPlatformSSLPrivateKey="/etc/stunnel/greenbuttonalliance_2016_11_16.key"
+
+// stunnel proxy
+stunnelConfigDirectory="/etc/stunnel"
+stunnelStatusCmd="sudo netstat -lpn | grep :80*"
+stunnelStartCmd="sudo /etc/init.d/stunnel4 start"
+stunnelStopCmd="sudo /etc/init.d/stunnel4 stop"
+stunnelReceiveAddress="192.168.1.167:8444"
+
+// configuration of test harness (not from testee)
+CApathDirectory="/etc/ssl/certs"
+opensslCmd="openssl"
+timeoutCmd="timeout"
+securityTimeout="2"
+mockPort="8081"
+proxyOutPort="8080"
+proxyOutPort1="8082"
+
+genericGetServiceMockPort="8086"
+

--- a/SOAPUI/etc/toTestCMDLocal.sh
+++ b/SOAPUI/etc/toTestCMDLocal.sh
@@ -3,4 +3,5 @@ cp prepopulatesql_applicationinformation_dc_testcmdlocal.sql prepopulatesql_appl
 cp prepopulatesql_tokenstore_testcmdlocal.sql prepopulatesql_tokenstore.sql
 cp gbcmdcert_target_testcmdlocal.conf gbcmdcert_target.conf
 cp gbcmd_secure.conf gbcmd.conf
+cp gbcmdcert_testcmdlocal.conf gbcmdcert.conf
 ./initializedatabases.sh


### PR DESCRIPTION
Query parameter tests corrected to avoid local time conversions.