### PR TITLE
gbcmdcert_testcmdlocal.conf pointed to incorrect stunnel key files fo…

### DIFF
--- a/SOAPUI/etc/gbcmdcert_testcmdlocal.conf
+++ b/SOAPUI/etc/gbcmdcert_testcmdlocal.conf
@@ -7,8 +7,8 @@ NAESBPurchasedStandardsURI="https://www.naesb.org//pdf2/copyright.pdf"
 NISTFIPSCertScreen="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm"
 
 // Test Harness Platform SSL Certificate and Private Key
-soapUIPlatformSSLCertificate="/etc/stunnel/greenbuttonalliance_ssl_certificate_2016_11_16.pem"
-soapUIPlatformSSLPrivateKey="/etc/stunnel/greenbuttonalliance_2016_11_16.key"
+soapUIPlatformSSLCertificate="/etc/stunnel/openespi.pem"
+soapUIPlatformSSLPrivateKey="/etc/stunnel/openespi_private_key.pem"
 
 // stunnel proxy
 stunnelConfigDirectory="/etc/stunnel"


### PR DESCRIPTION
gbcmdcert_testcmdlocal.conf pointed to incorrect stunnel key files for setup. Also added library script to aid in initializing meter data for CMD testing 'CMD openESPI UploadTestFile GUI'.