### PR TITLE
added SNI support for ssl certificate retrieval

### DIFF
--- a/ConfiguringTestTarget.md
+++ b/ConfiguringTestTarget.md
@@ -86,7 +86,7 @@ Authorization, and SFTP servers.  Elements shown in brackets "{}" indicate conte
 gbcmdcert_target.conf file.  
 
 	cd /etc/stunnel
-	sudo echo Q | openssl s_client -showcerts -connect {testAuthorizationServerDomain} | {testResourceServerDomain} | {testSFTPServerDomain} | {productionAuthorizationServerDomain} | {productionResourceServerDomain} | {productionSFTPServerDomain} -CApath /etc/ssl/certs -cert greenbuttonalliance_org_SSL_Cert.crt -key greenbuttonalliance_private_key.pem  | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ~/Desktop/{testAuthorizationServerDomain} | {testResourceServerDomain} | {testSFTPServerDomain} | {productionAuthorizationServerDomain} | {productionResourceServerDomain} | {productionSFTPServerDomain}.pem
+	sudo echo Q | openssl s_client -showcerts -servername {testAuthorizationServerDomain} -connect {testAuthorizationServerDomain} | {testResourceServerDomain} | {testSFTPServerDomain} | {productionAuthorizationServerDomain} | {productionResourceServerDomain} | {productionSFTPServerDomain} -CApath /etc/ssl/certs -cert greenbuttonalliance_org_SSL_Cert.crt -key greenbuttonalliance_private_key.pem  | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ~/Desktop/{testAuthorizationServerDomain} | {testResourceServerDomain} | {testSFTPServerDomain} | {productionAuthorizationServerDomain} | {productionResourceServerDomain} | {productionSFTPServerDomain}.pem
 	
 	sudo cp ~/Desktop/{testAuthorizationServerDomain} | {testResourceServerDomain} | {testSFTPServerDomain} | {productionAuthorizationServerDomain} | {productionResourceServerDomain} | {productionSFTPServerDomain}.pem /etc/ssl/certs/{testAuthorizationServerDomain} | {testResourceServerDomain} | {testSFTPServerDomain} | {productionAuthorizationServerDomain} | {productionResourceServerDomain} | {productionSFTPServerDomain}.pem
 	cd /etc/ssl/certs
@@ -100,7 +100,7 @@ shown in brackets "{}" indicate contents of the gbcmdcert_target.conf file.  Ver
 return code:0 (ok):
 
 	cd /etc/stunnel
-	echo Q | openssl s_client -verify 10 -showcerts -CApath /etc/ssl/certs -cert greenbuttonalliance_org_SSL_Cert.crt -key greenbuttonalliance_private_key.pem -connect {testAuthorizationServerDomain} | {testResourceServerDomain} | {testSFTPServerDomain} | {productionAuthorizationServerDomain} | {productionResourceServerDomain} | {productionSFTPServerDomain}  
+	echo Q | openssl s_client -verify 10 -showcerts -CApath /etc/ssl/certs -cert greenbuttonalliance_org_SSL_Cert.crt -key greenbuttonalliance_private_key.pem -servername {testAuthorizationServerDomain} -connect {testAuthorizationServerDomain} | {testResourceServerDomain} | {testSFTPServerDomain} | {productionAuthorizationServerDomain} | {productionResourceServerDomain} | {productionSFTPServerDomain}  
 
 Note: If there are any errors listed in the exchange (even if the verify is ok) you may need to check intermediate
 certificates in the chain from the "-showcerts" parameter. If so, you may need to acquire these certificates from

--- a/SOAPUI/GBCMD-soapui-project.xml
+++ b/SOAPUI/GBCMD-soapui-project.xml
@@ -16804,8 +16804,8 @@ strDCCertStoragePath = "/etc/ssl/certs/";
 strAuthServerIP = project.getPropertyValue( "authorizationServerIP" ) + ":" + project.getPropertyValue( "authorizationServerPort" );
 strDCCertName=hostResource + ".pem";
 
-//strCommand="echo Q | openssl s_client -showcerts -connect " + strAuthServerIP + " -CApath /etc/ssl/certs -cert /etc/stunnel/greenbuttonalliance_org_SSL_Cert.crt -key /etc/stunnel/greenbuttonalliance_private_key.pem | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > " + strDCCertStoragePathTmp + strDCCertName;
-strCommand="echo Q | openssl s_client -showcerts -connect " + strAuthServerIP + " -CApath /etc/ssl/certs -cert " + project.getPropertyValue("soapUIPlatformSSLCertificate") + " -key " + project.getPropertyValue("soapUIPlatformSSLPrivateKey") + " | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > " + strDCCertStoragePathTmp + strDCCertName;
+//strCommand="echo Q | openssl s_client -showcerts -connect " + strAuthServerIP + " -servername " + hostResource + " -CApath /etc/ssl/certs -cert /etc/stunnel/greenbuttonalliance_org_SSL_Cert.crt -key /etc/stunnel/greenbuttonalliance_private_key.pem | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > " + strDCCertStoragePathTmp + strDCCertName;
+strCommand="echo Q | openssl s_client -showcerts -connect " + strAuthServerIP + " -servername " + hostResource + " -CApath /etc/ssl/certs -cert " + project.getPropertyValue("soapUIPlatformSSLCertificate") + " -key " + project.getPropertyValue("soapUIPlatformSSLPrivateKey") + " | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > " + strDCCertStoragePathTmp + strDCCertName;
 
 
 tc.setPropertyValue("cmd", strCommand);

--- a/SOAPUI/etc/getcert.sh
+++ b/SOAPUI/etc/getcert.sh
@@ -1,6 +1,6 @@
 # run script that takes host ($1) and port ($2) as arguments to retrieve certificate 
 cd /etc/stunnel
-sudo echo Q | openssl s_client -showcerts -connect $1:$2 -CApath /etc/ssl/certs -cert openespi.pem -key openespi_private_key.pem  | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ~/Desktop/$1.pem
+sudo echo Q | openssl s_client -showcerts -connect $1:$2 -servername $1 -CApath /etc/ssl/certs -cert openespi.pem -key openespi_private_key.pem  | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ~/Desktop/$1.pem
 
 
 sudo cp ~/Desktop/$1.pem /etc/ssl/certs/$1.pem


### PR DESCRIPTION
OpenSSL allows you to specify the particular server host you want to request the certificate for via the `-servername` flag. This means that the test suite works with servers using SNI for their ssl certificates.